### PR TITLE
Fix protoc-gen-grpc-web static link errors

### DIFF
--- a/javascript/net/grpc/web/Makefile
+++ b/javascript/net/grpc/web/Makefile
@@ -32,8 +32,8 @@
 CXX = g++
 CPPFLAGS += -I/usr/local/include -pthread
 CXXFLAGS += -std=c++11
-LDFLAGS += -L/usr/local/lib -Wl,--no-as-needed -lprotobuf \
-  -lprotoc -lpthread -ldl
+LDFLAGS += -L/usr/local/lib -Wl,--no-as-needed -lprotoc \
+  -lprotobuf -lpthread -ldl
 
 all: protoc-gen-grpc-web
 


### PR DESCRIPTION
Resubmission of #8 with the new commit history.  Note that the error this fixes only occurs when linking to the static protobuf libraries.  Copy of the original description:

When trying to create the protoc-gen-grpc-web plugin I get loads of unresolved symbol errors, e.g.

```
/usr/local/lib/libprotoc.a(plugin.o): In function `CreateInternal<google::protobuf::compiler::CodeGeneratorResponse_File>':
/home/ubuntu/grpc/third_party/protobuf/src/./google/protobuf/arena.h:640: undefined reference to `google::protobuf::Arena::AllocateAligned(std::type_info const*, unsigned long)'
/home/ubuntu/grpc/third_party/protobuf/src/./google/protobuf/arena.h:642: undefined reference to `google::protobuf::Arena::AddListNode(void*, void (*)(void*))'
/usr/local/lib/libprotoc.a(plugin.o): In function `google::protobuf::compiler::GenerateCode(google::protobuf::compiler::CodeGeneratorRequest const&, google::protobuf::compiler::CodeGenerator const&, google::protobuf::compiler::CodeGeneratorResponse*, std::string*)':
/home/ubuntu/grpc/third_party/protobuf/src/google/protobuf/compiler/plugin.cc:99: undefined reference to `google::protobuf::DescriptorPool::DescriptorPool()'
<etc>
```

This can be fixed by switching the link order of the protoc and protobuf libraries.

Building on a Ubuntu 14.04 based docker container
`g++ (Ubuntu 4.8.4-2ubuntu1~14.04.1) 4.8.4`
`GNU ld (GNU Binutils for Ubuntu) 2.24`
Protobuf was built from source:
grpc git hash `52fd9f1119a95b6f22366551c0b2154b776f4aa7` (v1.0.x branch)
protobuf git hash `e8ae137c96444ea313485ed1118c5e43b2099cf1` (whatever gets checked out with the above grpc branch)