### PR TITLE
Fix makefiles for Mac OS X

### DIFF
--- a/javascript/net/grpc/web/Makefile
+++ b/javascript/net/grpc/web/Makefile
@@ -29,11 +29,17 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+OS := $(shell uname)
 CXX = g++
 CPPFLAGS += -I/usr/local/include -pthread
 CXXFLAGS += -std=c++11
+ifeq ($(OS), Darwin)
+LDFLAGS += -L/usr/local/lib -lprotoc \
+  -lprotobuf -lpthread -ldl
+else
 LDFLAGS += -L/usr/local/lib -Wl,--no-as-needed -lprotoc \
   -lprotobuf -lpthread -ldl
+endif
 
 all: protoc-gen-grpc-web
 

--- a/net/grpc/gateway/examples/echo/Makefile
+++ b/net/grpc/gateway/examples/echo/Makefile
@@ -29,13 +29,20 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+OS := $(shell uname)
 ROOT_DIR = ../../../../..
 CXX = g++
 CPPFLAGS += -I/usr/local/include -I$(ROOT_DIR) -pthread
 CXXFLAGS += -std=c++11
+ifeq ($(OS), Darwin)
+LDFLAGS += -L/usr/local/lib -lgrpc++ -lgrpc \
+           -lgrpc++_reflection              \
+           -lprotobuf -lpthread -ldl
+else
 LDFLAGS += -L/usr/local/lib -lgrpc++ -lgrpc                       \
            -Wl,--no-as-needed -lgrpc++_reflection -Wl,--as-needed \
            -lprotobuf -lpthread -ldl
+endif
 PROTOC = protoc
 PROTOS_PATH = ../..
 CLOSUREBUILDER = closure/bin/build/closurebuilder.py


### PR DESCRIPTION
`--no-as-needed` and `--as-needed` produce an "unknown option" error on Mac OS X, so this skips them off the link options.

```
@(#)PROGRAM:ld  PROJECT:ld64-274.1
configured to support archs: armv6 armv7 armv7s arm64 i386 x86_64 x86_64h armv6m armv7k armv7m armv7em (tvOS)
LTO support using: LLVM version 8.0.0, (clang-800.0.42.1)
TAPI support using: Apple TAPI version 1.30
```