### PR TITLE
Correct the path in darwin_x86_64.sh to relative path, to make it portable with or without docker.

### DIFF
--- a/darwin_x86_64.sh
+++ b/darwin_x86_64.sh
@@ -1,6 +1,6 @@
 ./init_submodules.sh
 make clean
-cd /github/grpc-web/third_party/protobuf && ./autogen.sh && ./configure && make && cd ../..
-cd /github/grpc-web/third_party/grpc && make && cd ../..
+cd third_party/protobuf && ./autogen.sh && ./configure && make && cd ../..
+cd third_party/grpc && make && cd ../..
 export KERNEL_BITS=64
 make


### PR DESCRIPTION
Correct the path in darwin_x86_64.sh to relative path, to make it portable with or without docker.