### PR TITLE
Install grpc and protobuf when building on Mac. Since DYLD_LIBRARY_PATH cannot be passed to nginx configure script from El Cap.

### DIFF
--- a/darwin_x86_64.sh
+++ b/darwin_x86_64.sh
@@ -2,7 +2,7 @@
 make clean
 cd third_party/protobuf \
   && ./autogen.sh \
-  && ./configure 
+  && ./configure \
   && make install -j8 \
   && cd ../..
 cd third_party/grpc \


### PR DESCRIPTION
Install grpc and protobuf when building on Mac. Since DYLD_LIBRARY_PATH cannot be passed to nginx configure script from El Cap.