### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ nginx_config:
 	--with-http_ssl_module \
 	--with-http_v2_module \
 	--with-cc-opt="-I /usr/local/include -I $(ROOT_DIR) -I $(PROTO_SRC) \
--I $(GRPC_INC)" \
+-I $(GRPC_INC) -D_FILE_OFFSET_BITS=64" \
 	--with-ld-opt="$(NGINX_LD_OPT)" \
 	--with-openssl="$(ROOT_DIR)/third_party/openssl" \
 	--add-module="$(ROOT_DIR)/net/grpc/gateway/nginx"
@@ -52,7 +52,7 @@ nginx_config_static:
 	--with-http_ssl_module \
 	--with-http_v2_module \
 	--with-cc-opt="-I /usr/local/include -I $(ROOT_DIR) -I $(PROTO_SRC) \
--I $(GRPC_INC)" \
+-I $(GRPC_INC) -D_FILE_OFFSET_BITS=64" \
 	--with-ld-opt="$(NGINX_STATIC_LD_OPT)" \
 	--with-openssl="$(ROOT_DIR)/third_party/openssl" \
 	--add-module="$(ROOT_DIR)/net/grpc/gateway/nginx"


### PR DESCRIPTION
Citing Igor Sysoev:

> Yes, you should either include ngx_config.h before your includes or set -D_FILE_OFFSET_BITS=64 in CFLAGS.


I think the less annoying one is the second choice.