### PR TITLE
Removed http2 port from example nginx.conf

### DIFF
--- a/net/grpc/gateway/examples/echo/nginx.conf
+++ b/net/grpc/gateway/examples/echo/nginx.conf
@@ -22,7 +22,6 @@ http {
   }
   server {
     listen 9091;
-    listen 9092 http2;
     server_name localhost;
     location / {
       grpc_pass localhost:9090;


### PR DESCRIPTION
For #81. Currently the grpc-web JS client does not use the http2 port in the nginx gateway. Removing this line from the `nginx.conf` file to reduce confusion.