### PR TITLE
Decouple example build from nginx build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ package_static: nginx_static
 plugin:
 	cd "$(ROOT_DIR)"/javascript/net/grpc/web && make
 
-example: nginx plugin
+example: plugin
 	cd "$(ROOT_DIR)"/net/grpc/gateway/examples/echo && make
 
 install-example:

--- a/net/grpc/gateway/examples/echo/Makefile
+++ b/net/grpc/gateway/examples/echo/Makefile
@@ -51,11 +51,7 @@ GRPC_WEB_PLUGIN_PATH = $(ROOT_DIR)/$(JS_PATH)/protoc-gen-grpc-web
 all: echo_server client package
 
 package:
-	mkdir -p $(ROOT_DIR)/gConnector/conf
 	mkdir -p $(ROOT_DIR)/gConnector/$(EXAMPLES_PATH)
-	cp $(ROOT_DIR)/net/grpc/gateway/nginx/package/nginx.sh $(ROOT_DIR)/gConnector
-	cp $(ROOT_DIR)/third_party/nginx/src/objs/nginx $(ROOT_DIR)/gConnector
-	cp $(ROOT_DIR)/third_party/nginx/src/conf/* $(ROOT_DIR)/gConnector/conf
 	cp nginx.conf $(ROOT_DIR)/gConnector/conf
 	cp echo_server $(ROOT_DIR)/gConnector
 	cp echotest.html $(ROOT_DIR)/gConnector/$(EXAMPLES_PATH)

--- a/net/grpc/gateway/examples/echo/README.md
+++ b/net/grpc/gateway/examples/echo/README.md
@@ -11,7 +11,7 @@ client) experiences.
 Use the [build scripts](https://github.com/grpc/grpc-web/blob/master/README.md)
 or follow the step-by-step instruction.
 
-* Ubuntu 14.04
+* Ubuntu
 
 ```sh
 $ sudo apt-get install autoconf automake build-essential curl git \
@@ -82,7 +82,8 @@ above steps.
 From the repo root directory:
 
 ```sh
-$ make example
+$ make package                  # build nginx
+$ make example                  # build client JS library
 $ sudo make install-example
 ```
 

--- a/net/grpc/gateway/examples/echo/tutorial.md
+++ b/net/grpc/gateway/examples/echo/tutorial.md
@@ -97,13 +97,13 @@ To generate the client stub JS file, you can now run this command:
 
 ```sh
 $ protoc -I=. --plugin=protoc-gen-grpc-web=<path to plugin> \
-  --grpc-web_out=out=echo.grpc.pb.js,mode=base64:. ./echo.proto
+  --grpc-web_out=out=echo.grpc.pb.js,mode=grpcweb:. ./echo.proto
 ```
 
 Specifically, the format for the `--grpc-web_out` param is
 
 ```sh
---grpc-web_out=out=<filename>,mode=base64:<output dir>
+--grpc-web_out=out=<filename>,mode=grpcweb:<output dir>
 ```
 
 This will generate the client stub in the file `echo.grpc.pb.js`.


### PR DESCRIPTION
 - We should re-use the root level `make` to build the nginx binary
 - running `make example` should not need to rebuild nginx