### PR TITLE
Fix path to init_submodules.sh in Dockerfile

### DIFF
--- a/net/grpc/gateway/docker/container_build/Dockerfile
+++ b/net/grpc/gateway/docker/container_build/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y \
 
 # Stage 2 init git submodules
 RUN cd /grpc-web && \
-  ./init_submodules.sh
+  ./scripts/init_submodules.sh
 
 # Stage 3 build the libraries
 RUN cd /grpc-web/third_party/grpc/third_party/protobuf && \


### PR DESCRIPTION
The recent reorganization of the script directory broke the Dockerfile build.