### PR TITLE
gRPC Sync

### DIFF
--- a/net/grpc/gateway/backend/backend.h
+++ b/net/grpc/gateway/backend/backend.h
@@ -23,7 +23,7 @@
 
 #include "net/grpc/gateway/runtime/request.h"
 #include "net/grpc/gateway/runtime/tag.h"
-#include "third_party/grpc/include/grpc++/support/status.h"
+#include "third_party/grpc/include/grpcpp/support/status.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/backend/grpc_backend.h
+++ b/net/grpc/gateway/backend/grpc_backend.h
@@ -26,7 +26,7 @@
 #include "net/grpc/gateway/runtime/request.h"
 #include "net/grpc/gateway/runtime/response.h"
 #include "net/grpc/gateway/runtime/tag.h"
-#include "third_party/grpc/include/grpc++/support/config.h"
+#include "third_party/grpc/include/grpcpp/support/config.h"
 #include "third_party/grpc/include/grpc/grpc.h"
 
 namespace grpc {

--- a/net/grpc/gateway/codec/b64_proto_decoder.h
+++ b/net/grpc/gateway/codec/b64_proto_decoder.h
@@ -21,7 +21,7 @@
 
 #include "net/grpc/gateway/codec/base64.h"
 #include "net/grpc/gateway/codec/proto_decoder.h"
-#include "third_party/grpc/include/grpc++/support/status.h"
+#include "third_party/grpc/include/grpcpp/support/status.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/b64_stream_body_decoder.cc
+++ b/net/grpc/gateway/codec/b64_stream_body_decoder.cc
@@ -21,8 +21,8 @@
 #include <vector>
 
 #include "net/grpc/gateway/codec/decoder.h"
-#include "third_party/grpc/include/grpc++/support/slice.h"
-#include "third_party/grpc/include/grpc++/support/status.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/status.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/b64_stream_body_decoder.h
+++ b/net/grpc/gateway/codec/b64_stream_body_decoder.h
@@ -21,7 +21,7 @@
 
 #include "net/grpc/gateway/codec/base64.h"
 #include "net/grpc/gateway/codec/stream_body_decoder.h"
-#include "third_party/grpc/include/grpc++/support/status.h"
+#include "third_party/grpc/include/grpcpp/support/status.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/b64_stream_body_encoder.h
+++ b/net/grpc/gateway/codec/b64_stream_body_encoder.h
@@ -24,9 +24,9 @@
 #include "net/grpc/gateway/codec/base64.h"
 #include "net/grpc/gateway/codec/stream_body_encoder.h"
 #include "net/grpc/gateway/runtime/types.h"
-#include "third_party/grpc/include/grpc++/support/byte_buffer.h"
-#include "third_party/grpc/include/grpc++/support/slice.h"
-#include "third_party/grpc/include/grpc++/support/status.h"
+#include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/status.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/base64.h
+++ b/net/grpc/gateway/codec/base64.h
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-#include "third_party/grpc/include/grpc++/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/decoder.h
+++ b/net/grpc/gateway/codec/decoder.h
@@ -23,8 +23,8 @@
 #include <memory>
 #include <vector>
 
-#include "third_party/grpc/include/grpc++/support/byte_buffer.h"
-#include "third_party/grpc/include/grpc++/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/encoder.h
+++ b/net/grpc/gateway/codec/encoder.h
@@ -20,7 +20,7 @@
 #define NET_GRPC_GATEWAY_CODEC_ENCODER_H_
 
 #include "net/grpc/gateway/runtime/types.h"
-#include "third_party/grpc/include/grpc++/support/byte_buffer.h"
+#include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/grpc_decoder.h
+++ b/net/grpc/gateway/codec/grpc_decoder.h
@@ -23,7 +23,7 @@
 #include <memory>
 
 #include "net/grpc/gateway/codec/decoder.h"
-#include "third_party/grpc/include/grpc++/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/grpc_encoder.cc
+++ b/net/grpc/gateway/codec/grpc_encoder.cc
@@ -18,7 +18,7 @@
 
 #include "net/grpc/gateway/codec/grpc_encoder.h"
 
-#include "third_party/grpc/include/grpc++/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/grpc_web_decoder.h
+++ b/net/grpc/gateway/codec/grpc_web_decoder.h
@@ -23,7 +23,7 @@
 #include <memory>
 
 #include "net/grpc/gateway/codec/decoder.h"
-#include "third_party/grpc/include/grpc++/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/grpc_web_encoder.cc
+++ b/net/grpc/gateway/codec/grpc_web_encoder.cc
@@ -23,8 +23,8 @@
 #include <vector>
 
 #include "net/grpc/gateway/runtime/types.h"
-#include "third_party/grpc/include/grpc++/support/byte_buffer.h"
-#include "third_party/grpc/include/grpc++/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/json_decoder.h
+++ b/net/grpc/gateway/codec/json_decoder.h
@@ -24,8 +24,8 @@
 
 #include "net/grpc/gateway/codec/base64.h"
 #include "net/grpc/gateway/codec/decoder.h"
-#include "third_party/grpc/include/grpc++/support/byte_buffer.h"
-#include "third_party/grpc/include/grpc++/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/json_encoder.cc
+++ b/net/grpc/gateway/codec/json_encoder.cc
@@ -24,7 +24,7 @@
 #include "net/grpc/gateway/protos/pair.pb.h"
 #include "net/grpc/gateway/protos/stream_body.pb.h"
 #include "net/grpc/gateway/runtime/constants.h"
-#include "third_party/grpc/include/grpc++/support/config.h"
+#include "third_party/grpc/include/grpcpp/support/config.h"
 #include "third_party/grpc/include/grpc/slice.h"
 
 namespace grpc {

--- a/net/grpc/gateway/codec/json_encoder.h
+++ b/net/grpc/gateway/codec/json_encoder.h
@@ -23,8 +23,8 @@
 
 #include "net/grpc/gateway/codec/base64.h"
 #include "net/grpc/gateway/codec/encoder.h"
-#include "third_party/grpc/include/grpc++/support/byte_buffer.h"
-#include "third_party/grpc/include/grpc++/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/proto_decoder.cc
+++ b/net/grpc/gateway/codec/proto_decoder.cc
@@ -18,8 +18,8 @@
 
 #include "net/grpc/gateway/codec/proto_decoder.h"
 
-#include "third_party/grpc/include/grpc++/support/byte_buffer.h"
-#include "third_party/grpc/include/grpc++/support/status.h"
+#include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
+#include "third_party/grpc/include/grpcpp/support/status.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/proto_encoder.cc
+++ b/net/grpc/gateway/codec/proto_encoder.cc
@@ -26,8 +26,8 @@
 #include "net/grpc/gateway/protos/stream_body.pb.h"
 #include "net/grpc/gateway/runtime/constants.h"
 #include "net/grpc/gateway/runtime/types.h"
-#include "third_party/grpc/include/grpc++/support/byte_buffer.h"
-#include "third_party/grpc/include/grpc++/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
 #include "third_party/grpc/include/grpc/slice.h"
 
 namespace grpc {

--- a/net/grpc/gateway/codec/stream_body_decoder.h
+++ b/net/grpc/gateway/codec/stream_body_decoder.h
@@ -23,8 +23,8 @@
 #include <vector>
 
 #include "net/grpc/gateway/codec/decoder.h"
-#include "third_party/grpc/include/grpc++/support/byte_buffer.h"
-#include "third_party/grpc/include/grpc++/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/stream_body_encoder.cc
+++ b/net/grpc/gateway/codec/stream_body_encoder.cc
@@ -28,7 +28,7 @@
 #include "net/grpc/gateway/protos/pair.pb.h"
 #include "net/grpc/gateway/protos/stream_body.pb.h"
 #include "net/grpc/gateway/runtime/constants.h"
-#include "third_party/grpc/include/grpc++/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/codec/stream_body_encoder.h
+++ b/net/grpc/gateway/codec/stream_body_encoder.h
@@ -20,7 +20,7 @@
 #define NET_GRPC_GATEWAY_CODEC_STREAM_BODY_ENCODER_H_
 
 #include "net/grpc/gateway/codec/encoder.h"
-#include "third_party/grpc/include/grpc++/support/byte_buffer.h"
+#include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/examples/echo/echo_server.cc
+++ b/net/grpc/gateway/examples/echo/echo_server.cc
@@ -16,7 +16,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <unistd.h>
 #include <string>
 

--- a/net/grpc/gateway/examples/echo/echo_service_impl.cc
+++ b/net/grpc/gateway/examples/echo/echo_service_impl.cc
@@ -18,7 +18,7 @@
 
 #include "net/grpc/gateway/examples/echo/echo_service_impl.h"
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <unistd.h>
 #include <string>
 

--- a/net/grpc/gateway/examples/echo/echo_service_impl.h
+++ b/net/grpc/gateway/examples/echo/echo_service_impl.h
@@ -19,7 +19,7 @@
  *
  */
 
-#include <grpc++/grpc++.h>
+#include <grpcpp/grpcpp.h>
 #include <unistd.h>
 #include <string>
 

--- a/net/grpc/gateway/frontend/nginx_http_frontend.h
+++ b/net/grpc/gateway/frontend/nginx_http_frontend.h
@@ -32,8 +32,8 @@
 #include "net/grpc/gateway/codec/encoder.h"
 #include "net/grpc/gateway/frontend/frontend.h"
 #include "net/grpc/gateway/runtime/constants.h"
-#include "third_party/grpc/include/grpc++/support/byte_buffer.h"
-#include "third_party/grpc/include/grpc++/support/string_ref.h"
+#include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
+#include "third_party/grpc/include/grpcpp/support/string_ref.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/net/grpc/gateway/log.h
+++ b/net/grpc/gateway/log.h
@@ -20,6 +20,7 @@
 #define NET_GRPC_GATEWAY_LOG_H_
 
 #include "third_party/grpc/include/grpc/support/log.h"
+#include <inttypes.h>
 
 #define INFO_0(f) gpr_log(GPR_INFO, f);
 #define INFO_1(f, v1) gpr_log(GPR_INFO, f, v1);

--- a/net/grpc/gateway/nginx_utils.h
+++ b/net/grpc/gateway/nginx_utils.h
@@ -23,7 +23,7 @@
 #include "net/grpc/gateway/nginx_includes.h"
 
 #include "net/grpc/gateway/log.h"
-#include "third_party/grpc/include/grpc++/support/string_ref.h"
+#include "third_party/grpc/include/grpcpp/support/string_ref.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/runtime/response.h
+++ b/net/grpc/gateway/runtime/response.h
@@ -23,7 +23,7 @@
 #include <memory>
 
 #include "net/grpc/gateway/runtime/types.h"
-#include "third_party/grpc/include/grpc++/support/status.h"
+#include "third_party/grpc/include/grpcpp/support/status.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/runtime/runtime.cc
+++ b/net/grpc/gateway/runtime/runtime.cc
@@ -43,7 +43,7 @@
 #include "net/grpc/gateway/codec/stream_body_encoder.h"
 #include "net/grpc/gateway/frontend/nginx_http_frontend.h"
 #include "net/grpc/gateway/runtime/constants.h"
-#include "third_party/grpc/include/grpc++/support/config.h"
+#include "third_party/grpc/include/grpcpp/support/config.h"
 #include "third_party/grpc/include/grpc/grpc.h"
 #include "third_party/grpc/include/grpc/grpc_security.h"
 

--- a/net/grpc/gateway/runtime/types.h
+++ b/net/grpc/gateway/runtime/types.h
@@ -23,8 +23,8 @@
 #include <utility>
 #include <vector>
 
-#include "third_party/grpc/include/grpc++/support/slice.h"
-#include "third_party/grpc/include/grpc++/support/string_ref.h"
+#include "third_party/grpc/include/grpcpp/support/slice.h"
+#include "third_party/grpc/include/grpcpp/support/string_ref.h"
 
 namespace grpc {
 namespace gateway {

--- a/net/grpc/gateway/utils.h
+++ b/net/grpc/gateway/utils.h
@@ -19,7 +19,7 @@
 #ifndef NET_GRPC_GATEWAY_UTILS_H_
 #define NET_GRPC_GATEWAY_UTILS_H_
 
-#include "third_party/grpc/include/grpc++/support/config.h"
+#include "third_party/grpc/include/grpcpp/support/config.h"
 
 namespace grpc {
 namespace gateway {

--- a/scripts/init_submodules.sh
+++ b/scripts/init_submodules.sh
@@ -18,4 +18,4 @@ cd "$(dirname "$0")"/..
 git submodule update --init
 cd third_party/closure-library && git checkout tags/v20171112 -f && cd ../..
 cd third_party/openssl && git checkout tags/OpenSSL_1_0_2h -f && cd ../..
-cd third_party/grpc && git checkout 8b875ac -f && git submodule update --init && cd ../..
+cd third_party/grpc && git checkout ac0188e -f && git submodule update --init && cd ../..


### PR DESCRIPTION
gRPC removed `#include <inttypes.h>` from `include/grpc/support/log.h` in the PR https://github.com/grpc/grpc/pull/14676/files, and it broke this gRPC-Web OSS build. So I propose we add it back in our `net/grpc/gateway/log.h`. @fengli79 Please see if this is an appropriate way of fixing this.