### PR TITLE
Add options to suppress cors preflight

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -40,6 +40,7 @@ const XmlHttp = goog.require('goog.net.XmlHttp');
 const events = goog.require('goog.events');
 const googCrypt = goog.require('goog.crypt.base64');
 const {GenericTransportInterface} = goog.require('grpc.web.GenericTransportInterface');
+const {Status} = goog.require('grpc.web.Status');
 
 
 
@@ -80,7 +81,7 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
 
   /**
    * @private
-   * @type {function(!grpc.web.Status)|null} The status callback
+   * @type {function(!Status)|null} The status callback
    */
   this.onStatusCallback_ = null;
 


### PR DESCRIPTION
Spec: https://github.com/grpc/grpc-web/blob/master/PROTOCOL-WEB.md#cors-support (second bullet point)

Add this option when creating the service client (3rd parameter in the constructor):
 
```
{ suppressCorsPreflight: true }
```

Note: this needs support on the proxy. We are working on adding the support to the Nginx module and Envoy soon. 