### PR TITLE
Add Envoy config file

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,17 +67,5 @@ Make sure `closure-compiler.jar` is put in the repo root directory after the
 above steps.
 
 
-## Build!
-
-From the repo root directory:
-
-```sh
-$ make         # build the nginx gateway
-
-# On MacOS Sierra or above, you might need to run this instead
-# KERNEL_BITS=64 make
-```
-
-
 For more example on how to build the client and an end-to-end example, please
 see [this page](net/grpc/gateway/examples/echo).

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,12 @@ plugin:
 example: plugin
 	cd "$(ROOT_DIR)"/net/grpc/gateway/examples/echo && make
 
+echo_server:
+	cd "$(ROOT_DIR)"/net/grpc/gateway/examples/echo && make echo_server
+
+client: plugin
+	cd "$(ROOT_DIR)"/net/grpc/gateway/examples/echo && make client
+
 install-example:
 	cd "$(ROOT_DIR)"/net/grpc/gateway/examples/echo && make install
 

--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ gRPC-Web provides a Javascript client library that lets browser clients
 access a gRPC server. You can find out much more about gRPC in its own
 [website](https://grpc.io).
 
-The current release is a Beta release, and we expect to announce General-Available by Oct. 2018. 
+The current release is a Beta release, and we expect to announce
+General-Available by Oct. 2018. 
 
-The JS client library has been
-used for some time by Google and Alphabet projects with the
+The JS client library has been used for some time by Google and Alphabet
+projects with the
 [Closure compiler](https://github.com/google/closure-compiler)
 and its TypeScript generator (which has not yet been open-sourced).
 
 gRPC-Web clients connect to gRPC servers via a special gateway proxy: our
-provided version uses Nginx. 
+provided version uses [Envoy](https://github.com/envoyproxy/envoy), in which
+gRPC-Web support is built-in. Envoy will become the default gateway for
+gRPC-Web by GA.
 
-We have also added built-in gRPC-Web support to
-[Envoy](https://github.com/lyft/envoy), which will become the default gateway for gRPC-Web by GA. 
-
-In future, we expect gRPC-Web to be supported in
+In the future, we expect gRPC-Web to be supported in
 language-specific Web frameworks, such as Python, Java, and Node. See the
 [roadmap](https://github.com/grpc/grpc-web/blob/master/ROADMAP.md) doc.
 
@@ -28,15 +28,13 @@ Try gRPC-Web and run a quick Echo example from the browser!
 From the repo root directory:
 
 ```sh
-$ docker build -t grpc-web --build-arg with_examples=true \
-  -f net/grpc/gateway/docker/ubuntu_16_04/Dockerfile .
-$ docker run -t -p 8080:8080 grpc-web
+$ docker-compose up
 ```
 
 Open a browser tab, and inspect
 
 ```
-http://localhost:8080/net/grpc/gateway/examples/echo/echotest.html
+http://localhost/net/grpc/gateway/examples/echo/echotest.html
 ```
 
 ## How it works
@@ -65,7 +63,7 @@ service EchoService {
 
 Next you need to have a gRPC server that implements the service interface and a
 gateway that allows the client to connect to the server. Our example builds a
-simple C++ gRPC backend server and the Nginx gateway. You can find out more in
+simple C++ gRPC backend server and the Envoy proxy. You can find out more in
 the [Echo Example](net/grpc/gateway/examples/echo).
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,10 @@ services:
       context: ./
       dockerfile: ./net/grpc/gateway/docker/envoy/Dockerfile
     image: grpc-web:envoy
-    network_mode: "host"
     ports:
       - "8080:8080"
+    links:
+      - echo-server
   static-assets:
     build:
       context: ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  prereqs:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/prereqs/Dockerfile
+    image: grpc-web:prereqs
+  echo-server:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/echo_server/Dockerfile
+    image: grpc-web:echo-server
+    ports:
+      - "9090:9090"
+  envoy:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/envoy/Dockerfile
+    image: grpc-web:envoy
+    network_mode: "host"
+    ports:
+      - "8080:8080"
+  static-assets:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/static_assets/Dockerfile
+    image: grpc-web:static-assets
+    ports:
+      - "80:80"

--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -41,7 +41,7 @@ using std::string;
 
 enum Mode {
   OP = 0,          // first party google3 one platform services
-  GATEWAY = 1,     // open-source gRPC Gateway, currently nginx
+  GATEWAY = 1,     // open-source gRPC Gateway
   OPJSPB = 2,      // first party google3 one platform services with JSPB
   FRAMEWORKS = 3,  // first party google3 AF services with AF data add-ons
   GRPCWEB = 4,     // client using the application/grpc-web wire format

--- a/net/grpc/gateway/docker/echo_server/Dockerfile
+++ b/net/grpc/gateway/docker/echo_server/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM grpc-web:prereqs
+
+RUN cd /github/grpc-web && \
+  make echo_server
+
+EXPOSE 9090
+CMD ["/github/grpc-web/net/grpc/gateway/examples/echo/echo_server"]

--- a/net/grpc/gateway/docker/envoy/Dockerfile
+++ b/net/grpc/gateway/docker/envoy/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM envoyproxy/envoy:latest
+
+COPY net/grpc/gateway/examples/echo/envoy.yaml /etc/envoy/envoy.yaml
+
+CMD /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l trace --log-path /tmp/envoy_info.log

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:16.04
+
+ARG MAKEFLAGS=-j8
+
+COPY . /github/grpc-web
+
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  automake \
+  build-essential \
+  curl \
+  git \
+  default-jdk \
+  default-jre \
+  libtool \
+  libssl-dev \
+  make \
+  nginx \
+  zip
+
+RUN cd /github/grpc-web && \
+  ./scripts/init_submodules.sh
+
+RUN cd /github/grpc-web/third_party/grpc && \
+  make && make install
+
+RUN cd /github/grpc-web/third_party/grpc/third_party/protobuf && \
+  make install

--- a/net/grpc/gateway/docker/static_assets/Dockerfile
+++ b/net/grpc/gateway/docker/static_assets/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM grpc-web:prereqs
+
+COPY net/grpc/gateway/examples/echo/nginx_simple.conf \
+  /etc/nginx/nginx.conf
+
+RUN cd /github/grpc-web && \
+  curl http://dl.google.com/closure-compiler/compiler-latest.zip \
+  -o /github/grpc-web/compiler-latest.zip
+
+RUN cd /github/grpc-web && \
+  rm -f /github/grpc-web/closure-compiler.jar && \
+  unzip -p -qq -o /github/grpc-web/compiler-latest.zip *.jar > \
+  /github/grpc-web/closure-compiler.jar
+
+RUN cd /github/grpc-web && \
+  make client && make install-example
+
+EXPOSE 80
+CMD ["nginx"]

--- a/net/grpc/gateway/examples/echo/README.md
+++ b/net/grpc/gateway/examples/echo/README.md
@@ -38,7 +38,7 @@ This compiles the gRPC backend server, written in C++, and listens on port
 ```sh
 $ docker build -t grpc-web:echo-server \
   -f net/grpc/gateway/docker/echo_server/Dockerfile .
-$ docker run -d -p 9090:9090 grpc-web:echo-server
+$ docker run -d -p 9090:9090 --name echo-server grpc-web:echo-server
 ```
 
 ## Run the Envoy proxy
@@ -49,7 +49,7 @@ requests will be forwarded to port 9090.
 ```sh
 $ docker build -t grpc-web:envoy \
   -f net/grpc/gateway/docker/envoy/Dockerfile .
-$ docker run -d --net="host" grpc-web:envoy
+$ docker run -d -p 8080:8080 --link echo-server:echo-server grpc-web:envoy
 ```
 
 ## Serve static JS/HTML contents

--- a/net/grpc/gateway/examples/echo/envoy.yaml
+++ b/net/grpc/gateway/examples/echo/envoy.yaml
@@ -40,4 +40,4 @@ static_resources:
     type: logical_dns
     http2_protocol_options: {}
     lb_policy: round_robin
-    hosts: [{ socket_address: { address: 0.0.0.0, port_value: 9090 }}]
+    hosts: [{ socket_address: { address: echo-server, port_value: 9090 }}]

--- a/net/grpc/gateway/examples/echo/envoy.yaml
+++ b/net/grpc/gateway/examples/echo/envoy.yaml
@@ -1,0 +1,43 @@
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 8080 }
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route: { cluster: echo_service }
+              cors:
+                allow_origin:
+                - "*"
+                allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web
+                max_age: "1728000"
+                allow_credentials: true
+                enabled: true
+          http_filters:
+          - name: envoy.grpc_web
+          - name: envoy.cors
+          - name: envoy.router
+  clusters:
+  - name: echo_service
+    connect_timeout: 0.25s
+    type: logical_dns
+    http2_protocol_options: {}
+    lb_policy: round_robin
+    hosts: [{ socket_address: { address: 0.0.0.0, port_value: 9090 }}]

--- a/net/grpc/gateway/examples/echo/nginx_simple.conf
+++ b/net/grpc/gateway/examples/echo/nginx_simple.conf
@@ -10,10 +10,6 @@ events {
 
 http {
   access_log off;
-  client_max_body_size 0;
-  client_body_temp_path client_body_temp;
-  proxy_temp_path proxy_temp;
-  proxy_request_buffering off;
   server {
     listen 80;
     server_name localhost;

--- a/net/grpc/gateway/examples/echo/nginx_simple.conf
+++ b/net/grpc/gateway/examples/echo/nginx_simple.conf
@@ -1,0 +1,24 @@
+master_process off;
+daemon off;
+worker_processes 1;
+pid nginx.pid;
+error_log stderr debug;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  access_log off;
+  client_max_body_size 0;
+  client_body_temp_path client_body_temp;
+  proxy_temp_path proxy_temp;
+  proxy_request_buffering off;
+  server {
+    listen 80;
+    server_name localhost;
+    location ~ \.(html|js)$ {
+      root /var/www/html;
+    }
+  }
+}


### PR DESCRIPTION
Main changes this PR:
 - Add an Envoy config file envoy.yaml, which will allow us to run the end-to-end Echo example swapping out Nginx with Envoy.
 - Replace references to Nginx with Envoy in documentations as much as possible
 - Split the end-to-end Echo examples into 4 Dockerfiles to make it more modular
    - prereqs, echo_server, envoy and static_assets
 - Add a docker-compose.yml file to further simplify the end-to-end example

To run:
- docker-compose up
- hit http://localhost/net/grpc/gateway/examples/echo/echotest.html

