### PR TITLE
npm package is now live

### DIFF
--- a/net/grpc/gateway/docker/commonjs_client_example/Dockerfile
+++ b/net/grpc/gateway/docker/commonjs_client_example/Dockerfile
@@ -16,12 +16,6 @@ FROM grpc-web:prereqs
 
 ARG EXAMPLE_DIR=/github/grpc-web/net/grpc/gateway/examples/echo
 
-RUN cd /github/grpc-web/packages/grpc-web && \
-  rm -rf node_modules && \
-  npm install && \
-  npm run build && \
-  npm link
-
 RUN protoc -I=$EXAMPLE_DIR echo.proto \
 --plugin=protoc-gen-grpc-web=\
 /github/grpc-web/javascript/net/grpc/web/protoc-gen-grpc-web \
@@ -33,7 +27,6 @@ $EXAMPLE_DIR/commonjs-example
 RUN cd $EXAMPLE_DIR/commonjs-example && \
   rm -rf node_modules && \
   npm install && \
-  npm link grpc-web && \
   ./node_modules/.bin/browserify client.js > out.js
 
 EXPOSE 8081

--- a/net/grpc/gateway/examples/echo/commonjs-example/package.json
+++ b/net/grpc/gateway/examples/echo/commonjs-example/package.json
@@ -3,8 +3,11 @@
   "version": "0.1.0",
   "description": "gRPC-Web CommonJS client example",
   "license": "Apache-2.0",
+  "dependencies": {
+    "google-protobuf": "3",
+    "grpc-web": "^0.2.0"
+  },
   "devDependencies": {
-    "browserify": "16",
-    "google-protobuf": "3"
+    "browserify": "16"
   }
 }

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "gRPC web runtime",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Our npm package https://www.npmjs.com/package/grpc-web is now live. `require('grpc-web');` now works without having to build the package locally.

Fixes #197 