### PR TITLE
Recursive proto demo

### DIFF
--- a/net/grpc/gateway/examples/echo/commonjs-example/client.js
+++ b/net/grpc/gateway/examples/echo/commonjs-example/client.js
@@ -1,4 +1,4 @@
-const {EchoRequest,
+const {Node, List, EchoRequest,
        ServerStreamingEchoRequest} = require('./echo_pb.js');
 const {EchoServiceClient} = require('./echo_grpc_pb.js');
 const {EchoApp} = require('../echoapp.js');
@@ -6,6 +6,17 @@ const grpc = {};
 grpc.web = require('grpc-web');
 
 var echoService = new EchoServiceClient('http://localhost:8080', null, null);
+
+var node1 = new Node();
+node1.setVal("node1");
+
+var list = new List();
+list.setNodesList([node1]);
+
+var node2 = new Node();
+node2.setList(list);
+
+console.log("node1.val = "+node2.getList().getNodesList()[0].getVal());
 
 var echoApp = new EchoApp(
   echoService,

--- a/net/grpc/gateway/examples/echo/echo.proto
+++ b/net/grpc/gateway/examples/echo/echo.proto
@@ -19,8 +19,20 @@ package grpc.gateway.testing;
 message Empty {
 }
 
+message Node {
+  oneof contents {
+    List list = 1;
+    string val = 2;
+  }
+}
+
+message List {
+  repeated Node nodes = 1;
+}
+
 message EchoRequest {
   string message = 1;
+  List list = 2;
 }
 
 message EchoResponse {


### PR DESCRIPTION
This is to show that recursive proto does work with CommonJS style `require()`, but doesn't work with the Closure compiler.

See #192 