### PR TITLE
Minor fix to nginx dockerfile

### DIFF
--- a/net/grpc/gateway/docker/nginx/Dockerfile
+++ b/net/grpc/gateway/docker/nginx/Dockerfile
@@ -14,6 +14,9 @@
 
 FROM grpc-web:prereqs
 
+RUN cd /github/grpc-web/net/grpc/gateway/examples/echo && \
+  sed -i 's/localhost:9090/echo-server:9090/g' nginx.conf
+
 RUN cd /github/grpc-web && \
   make standalone-proxy
 

--- a/net/grpc/gateway/examples/echo/nginx.conf
+++ b/net/grpc/gateway/examples/echo/nginx.conf
@@ -21,7 +21,7 @@ http {
       root /var/www/html;
     }
     location / {
-      grpc_pass echo-server:9090;
+      grpc_pass localhost:9090;
       if ($request_method = 'OPTIONS') {
         add_header 'Access-Control-Allow-Origin' '*';
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';


### PR DESCRIPTION
To bring up the end-to-end example, the address `echo-server:9090` is only relevant in the context of the nginx instance being run as a docker image.