### PR TITLE
Expose response metadata for unary calls

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -117,7 +117,7 @@ GrpcWebClientBase.prototype.rpcCall = function(
     xhr.setResponseType(XhrIo.ResponseType.ARRAY_BUFFER);
   }
   xhr.send(method, 'POST', payload);
-  return;
+  return stream;
 };
 
 

--- a/net/grpc/gateway/examples/echo/echoapp.js
+++ b/net/grpc/gateway/examples/echo/echoapp.js
@@ -46,8 +46,10 @@ echoapp.EchoApp.prototype.echo = function(msg) {
   echoapp.EchoApp.addLeftMessage(msg);
   var unaryRequest = new this.ctors.EchoRequest();
   unaryRequest.setMessage(msg);
-  this.echoService.echo(unaryRequest, {"custom-header-1": "value1"},
-                        function(err, response) {
+  var self = this;
+  var call = this.echoService.echo(unaryRequest,
+                                   {"custom-header-1": "value1"},
+                                   function(err, response) {
     if (err) {
       echoapp.EchoApp.addRightMessage('Error code: '+err.code+' "'+
                                       err.message+'"');
@@ -55,6 +57,13 @@ echoapp.EchoApp.prototype.echo = function(msg) {
       setTimeout(function () {
         echoapp.EchoApp.addRightMessage(response.getMessage());
       }, echoapp.EchoApp.INTERVAL);
+    }
+  });
+  call.on('status', function(status) {
+    self.handlers.checkGrpcStatusCode(status);
+    if (status.metadata) {
+      console.log("Received metadata");
+      console.log(status.metadata);
     }
   });
 };


### PR DESCRIPTION
Fixes #220 

Usage:
```
var call = service.echo(req, {}, function(err, response) {
  // ...
});
call.on('status', function(status) {
  if (status.metadata) {
    // ...
  }
});
```

Note: this is already supported for streaming calls.