### PR TITLE
Include `unusedPrivateMembers` to suppress attribute of rule

### DIFF
--- a/bazel/closure_grpc_web_library.bzl
+++ b/bazel/closure_grpc_web_library.bzl
@@ -123,6 +123,7 @@ def _closure_grpc_web_library_impl(ctx):
 
   suppress = [
       "misplacedTypeAnnotation",
+      "unusedPrivateMembers"
   ]
 
   library = closure_js_library_impl(


### PR DESCRIPTION
cc @Yannic

reason: 
```
ERROR: <…>/app/client/BUILD:40:1: Compiling 88 JavaScript files to app/client/service_js_binary.js failed (Exit 1)
bazel-out/darwin-fastbuild/bin/app/client/service.grpc.js:49: ERROR - Private property credentials_ is never read
  this.credentials_ = credentials;
  ^
  ProTip: "JSC_UNUSED_PRIVATE_PROPERTY" or "analyzerChecks" or "unusedPrivateMembers" can be added to the `suppress` attribute of:
  //app/client:service_grpc
  Alternatively /** @suppress {unusedPrivateMembers} */ can be added to the source file.

bazel-out/darwin-fastbuild/bin/app/client/service.grpc.js:54: ERROR - Private property options_ is never read
  this.options_ = options;
  ^
  ProTip: "JSC_UNUSED_PRIVATE_PROPERTY" or "analyzerChecks" or "unusedPrivateMembers" can be added to the `suppress` attribute of:
  //app/client:service_grpc
  Alternatively /** @suppress {unusedPrivateMembers} */ can be added to the source file.
```

I'm using [grpc-web @ 285608](https://github.com/grpc/grpc-web/tree/285608c4669d51973252931b02b791621b6ae1c5)