### PR TITLE
Closure compiler download link uses plain HTTP

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,7 +59,7 @@ $ sudo make install
 From the repo root directory:
 
 ```sh
-$ wget http://dl.google.com/closure-compiler/compiler-latest.zip -O compiler-latest.zip
+$ wget https://dl.google.com/closure-compiler/compiler-latest.zip -O compiler-latest.zip
 $ unzip -p -qq -o compiler-latest.zip *.jar > closure-compiler.jar
 ```
 


### PR DESCRIPTION
I may be wrong, but shouldn't this download happen over HTTPS?