### PR TITLE
Introduce grpc.web.ClientReadableStreamDelegate

### DIFF
--- a/javascript/net/grpc/web/BUILD.bazel
+++ b/javascript/net/grpc/web/BUILD.bazel
@@ -10,7 +10,7 @@ cc_binary(
         "grpc_generator.cc",
     ],
     deps = [
-        "@com_google_protobuf//:protoc_lib"
+        "@com_google_protobuf//:protoc_lib",
     ],
 )
 
@@ -30,6 +30,35 @@ closure_js_library(
     srcs = [
         "clientreadablestream.js",
     ],
+    deps = [
+        ":clientreadablestreamdelegate",
+    ],
+)
+
+closure_js_library(
+    name = "clientreadablestreamdelegate",
+    srcs = [
+        "clientreadablestreamdelegate.js",
+    ],
+    deps = [
+        ":error",
+        ":status",
+    ],
+)
+
+closure_js_library(
+    name = "defaultclientreadablestreamdelegate",
+    srcs = [
+        "defaultclientreadablestreamdelegate.js",
+    ],
+    suppress = [
+        "reportUnknownTypes",
+    ],
+    deps = [
+        ":clientreadablestreamdelegate",
+        ":error",
+        ":status",
+    ],
 )
 
 closure_js_library(
@@ -45,8 +74,8 @@ closure_js_library(
         "generictransportinterface.js",
     ],
     deps = [
-        "@io_bazel_rules_closure//closure/library/net/streams:nodereadablestream",
         "@io_bazel_rules_closure//closure/library/net:xhrio",
+        "@io_bazel_rules_closure//closure/library/net/streams:nodereadablestream",
     ],
 )
 
@@ -69,27 +98,54 @@ closure_js_library(
     ],
 )
 
+closure_js_test(
+    name = "grpcwebclientbase_test",
+    srcs = [
+        "grpcwebclientbase_test.js",
+    ],
+    entry_points = [
+        "goog:grpc.web.GrpcWebClientBaseTest",
+    ],
+    suppress = [
+        "visibility",
+        "checkTypes",
+        "deprecated",
+        "reportUnknownTypes",
+        "strictCheckTypes",
+    ],
+    deps = [
+        ":grpcwebclientbase",
+        "@io_bazel_rules_closure//closure/library/crypt:base64",
+        "@io_bazel_rules_closure//closure/library/events",
+        "@io_bazel_rules_closure//closure/library/structs:map",
+        "@io_bazel_rules_closure//closure/library/testing:jsunit",
+        "@io_bazel_rules_closure//closure/library/testing:testsuite",
+    ],
+)
+
 closure_js_library(
     name = "grpcwebclientreadablestream",
     srcs = [
         "grpcwebclientreadablestream.js",
     ],
+    suppress = [
+        "reportUnknownTypes",
+    ],
     deps = [
         ":clientreadablestream",
+        ":clientreadablestreamdelegate",
+        ":defaultclientreadablestreamdelegate",
         ":generictransportinterface",
         ":grpcwebstreamparser",
-        ":status",
         ":statuscode",
+        "@io_bazel_rules_closure//closure/library/asserts",
         "@io_bazel_rules_closure//closure/library/crypt:base64",
-        "@io_bazel_rules_closure//closure/library/events:events",
+        "@io_bazel_rules_closure//closure/library/events",
         "@io_bazel_rules_closure//closure/library/net:errorcode",
         "@io_bazel_rules_closure//closure/library/net:eventtype",
         "@io_bazel_rules_closure//closure/library/net:xhrio",
         "@io_bazel_rules_closure//closure/library/net:xmlhttp",
         "@io_bazel_rules_closure//closure/library/string",
-    ],
-    suppress = [
-        "reportUnknownTypes",
     ],
 )
 
@@ -107,6 +163,24 @@ closure_js_library(
     ],
 )
 
+closure_js_test(
+    name = "grpcwebstreamparser_test",
+    srcs = [
+        "grpcwebstreamparser_test.js",
+    ],
+    entry_points = [
+        "goog:grpc.web.GrpcWebStreamParserTest",
+    ],
+    suppress = [
+        "reportUnknownTypes",
+    ],
+    deps = [
+        ":grpcwebstreamparser",
+        "@io_bazel_rules_closure//closure/library/testing:jsunit",
+        "@io_bazel_rules_closure//closure/library/testing:testsuite",
+    ],
+)
+
 closure_js_library(
     name = "status",
     srcs = [
@@ -121,43 +195,40 @@ closure_js_library(
     ],
 )
 
-closure_js_test(
-    name = "grpcwebclientbase_test",
+closure_js_library(
+    name = "streambodyclientreadablestream",
     srcs = [
-        "grpcwebclientbase_test.js",
-    ],
-    entry_points = [
-        "goog:grpc.web.GrpcWebClientBaseTest",
+        "streambodyclientreadablestream.js",
     ],
     suppress = [
-        "visibility",
-        "checkTypes",
-        "deprecated",
         "reportUnknownTypes",
-        "strictCheckTypes",
     ],
     deps = [
-        "@io_bazel_rules_closure//closure/library:testing",
-        "@io_bazel_rules_closure//closure/library/crypt:base64",
-        "@io_bazel_rules_closure//closure/library/events:events",
-        "@io_bazel_rules_closure//closure/library/structs:map",
-        ":grpcwebclientbase",
+        ":clientreadablestream",
+        ":clientreadablestreamdelegate",
+        ":defaultclientreadablestreamdelegate",
+        ":generictransportinterface",
+        ":status",
+        ":statuscode",
+        "@io_bazel_rules_closure//closure/library/asserts",
+        "@io_bazel_rules_closure//closure/library/net:errorcode",
+        "@io_bazel_rules_closure//closure/library/net:xhrio",
+        "@io_bazel_rules_closure//closure/library/net/streams:nodereadablestream",
     ],
 )
 
 closure_js_test(
-    name = "grpcwebstreamparser_test",
+    name = "streambodyclientreadablestream_test",
     srcs = [
-        "grpcwebstreamparser_test.js",
+        "streambodyclientreadablestream_test.js",
     ],
     entry_points = [
-        "goog:grpc.web.GrpcWebStreamParserTest",
-    ],
-    suppress = [
-        "reportUnknownTypes",
+        "goog:grpc.web.StreamBodyClientReadableStreamTest",
     ],
     deps = [
-        ":grpcwebstreamparser",
-        "@io_bazel_rules_closure//closure/library:testing",
+        ":streambodyclientreadablestream",
+        "@io_bazel_rules_closure//closure/library/reflect",
+        "@io_bazel_rules_closure//closure/library/testing:jsunit",
+        "@io_bazel_rules_closure//closure/library/testing:testsuite",
     ],
 )

--- a/javascript/net/grpc/web/clientreadablestream.js
+++ b/javascript/net/grpc/web/clientreadablestream.js
@@ -30,6 +30,8 @@ goog.module('grpc.web.ClientReadableStream');
 
 goog.module.declareLegacyNamespace();
 
+const ClientReadableStreamDelegate = goog.require('grpc.web.ClientReadableStreamDelegate');
+
 
 
 /**
@@ -51,6 +53,13 @@ const ClientReadableStream = function() {};
  * @return {!ClientReadableStream} this object
  */
 ClientReadableStream.prototype.on = goog.abstractMethod;
+
+
+/**
+ * @param {!ClientReadableStreamDelegate} delegate
+ * @return {!ClientReadableStream}
+ */
+ClientReadableStream.prototype.setDelegate = goog.abstractMethod;
 
 
 

--- a/javascript/net/grpc/web/clientreadablestreamdelegate.js
+++ b/javascript/net/grpc/web/clientreadablestreamdelegate.js
@@ -1,0 +1,63 @@
+/**
+ *
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+goog.module('grpc.web.ClientReadableStreamDelegate');
+
+goog.module.declareLegacyNamespace();
+
+// const Error = goog.require('grpc.web.Error');
+const {Status} = goog.require('grpc.web.Status');
+
+
+
+/**
+ * @template RESPONSE
+ * @interface
+ */
+const ClientReadableStreamDelegate = function() {};
+
+
+/**
+ * @param {!RESPONSE} message
+ * @return {void}
+ */
+ClientReadableStreamDelegate.prototype.onData = goog.abstractMethod;
+
+
+/**
+ * @return {void}
+ */
+ClientReadableStreamDelegate.prototype.onEnd = goog.abstractMethod;
+
+
+/**
+ * @param {...} message
+ * @return {void}
+ */
+ClientReadableStreamDelegate.prototype.onError = goog.abstractMethod;
+
+
+/**
+ * @param {!Status} message
+ * @return {void}
+ */
+ClientReadableStreamDelegate.prototype.onStatus = goog.abstractMethod;
+
+
+
+exports = ClientReadableStreamDelegate;

--- a/javascript/net/grpc/web/defaultclientreadablestreamdelegate.js
+++ b/javascript/net/grpc/web/defaultclientreadablestreamdelegate.js
@@ -1,0 +1,126 @@
+/**
+ *
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+goog.module('grpc.web.DefaultClientReadableStreamDelegate');
+
+goog.module.declareLegacyNamespace();
+
+const ClientReadableStreamDelegate = goog.require('grpc.web.ClientReadableStreamDelegate');
+const {Status} = goog.require('grpc.web.Status');
+
+
+
+/**
+ * @template RESPONSE
+ * @implements {ClientReadableStreamDelegate<RESPONSE>}
+ */
+class DefaultClientReadableStreamDelegate {
+  /**
+   * Creates a new Default Delegate.
+   */
+  constructor() {
+    /**
+     * @private {?function(!RESPONSE): void}
+     */
+    this.onDataCallback_ = null;
+
+    /**
+     * @private {?function(...): ?}
+     */
+    this.onErrorCallback_ = null;
+
+    /**
+     * @private {?function(): void}
+     */
+    this.onEndCallback_ = null;
+
+    /**
+     * @private {?function(!Status): void}
+     */
+    this.onStatusCallback_ = null;
+  }
+
+  /**
+   * @override
+   */
+  onData(data) {
+    if (!goog.isNull(this.onDataCallback_)) {
+      this.onDataCallback_(data);
+    }
+  }
+
+  /**
+   * @param {!function(!RESPONSE): void} callback
+   * @return {void}
+   */
+  setOnData(callback) {
+    this.onDataCallback_ = callback;
+  }
+
+  /**
+   * @override
+   */
+  onEnd() {
+    if (!goog.isNull(this.onEndCallback_)) {
+      this.onEndCallback_();
+    }
+  }
+
+  /**
+   * @param {!function(): void} callback
+   * @return {void}
+   */
+  setOnEnd(callback) {
+    this.onEndCallback_ = callback;
+  }
+
+  /**
+   * @override
+   */
+  onError(error) {
+    if (!goog.isNull(this.onErrorCallback_)) {
+      this.onErrorCallback_(error);
+    }
+  }
+
+  /**
+   * @param {!function(...): ?} callback
+   * @return {void}
+   */
+  setOnError(callback) {
+    this.onErrorCallback_ = callback;
+  }
+
+  /**
+   * @override
+   */
+  onStatus(status) {
+    if (!goog.isNull(this.onStatusCallback_)) {
+      this.onStatusCallback_(status);
+    }
+  }
+
+  /**
+   * @param {!function(!Status): void} callback
+   * @return {void}
+   */
+  setOnStatus(callback) {
+    this.onStatusCallback_ = callback;
+  }
+}
+exports = DefaultClientReadableStreamDelegate;

--- a/javascript/net/grpc/web/streambodyclientreadablestream_test.js
+++ b/javascript/net/grpc/web/streambodyclientreadablestream_test.js
@@ -1,0 +1,34 @@
+/**
+ *
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+goog.module('grpc.web.StreamBodyClientReadableStreamTest');
+goog.setTestOnly();
+
+var GrpcWebStreamParser = goog.require('grpc.web.StreamBodyClientReadableStream');
+var testSuite = goog.require('goog.testing.testSuite');
+const {sinkValue} = goog.require('goog.reflect');
+goog.require('goog.testing.jsunit');
+
+
+
+testSuite({
+  // While this does not provide much code coverage,
+  // it ensures that the library compiles without errors.
+  testImport: () => {
+    sinkValue(GrpcWebStreamParser);
+  },
+});


### PR DESCRIPTION
This CL introduces `grpc.web.ClientReadableStreamDelegate`, a type-safe
alternative to `grpc.web.ClientReadableStream.prototype.on`. This is an
improvement for type-checking of clients which currently need to suppress
`reportUnknownTypes`.