### PR TITLE
Remove the need to pass out= to protoc plugin

### DIFF
--- a/net/grpc/gateway/docker/binary_client/Dockerfile
+++ b/net/grpc/gateway/docker/binary_client/Dockerfile
@@ -21,7 +21,7 @@ RUN protoc -I=$EXAMPLE_DIR echo.proto \
 /github/grpc-web/javascript/net/grpc/web/protoc-gen-grpc-web \
 --js_out=import_style=commonjs:\
 $EXAMPLE_DIR/commonjs-example \
---grpc-web_out=import_style=commonjs,mode=grpcweb,out=echo_grpc_pb.js:\
+--grpc-web_out=import_style=commonjs,mode=grpcweb:\
 $EXAMPLE_DIR/commonjs-example
 
 RUN cd $EXAMPLE_DIR/commonjs-example && \

--- a/net/grpc/gateway/docker/commonjs_client/Dockerfile
+++ b/net/grpc/gateway/docker/commonjs_client/Dockerfile
@@ -21,7 +21,7 @@ RUN protoc -I=$EXAMPLE_DIR echo.proto \
 /github/grpc-web/javascript/net/grpc/web/protoc-gen-grpc-web \
 --js_out=import_style=commonjs:\
 $EXAMPLE_DIR/commonjs-example \
---grpc-web_out=import_style=commonjs,mode=grpcwebtext,out=echo_grpc_pb.js:\
+--grpc-web_out=import_style=commonjs,mode=grpcwebtext:\
 $EXAMPLE_DIR/commonjs-example
 
 RUN cd $EXAMPLE_DIR/commonjs-example && \

--- a/net/grpc/gateway/examples/echo/Makefile
+++ b/net/grpc/gateway/examples/echo/Makefile
@@ -90,7 +90,7 @@ proto-js:
   $(PROTOS_PATH)/protos/pair.proto
 	$(PROTOC) -I=. --js_out=$(JS_IMPORT_STYLE):$(OUT_DIR) ./echo.proto
 	$(PROTOC) -I=. --plugin=protoc-gen-grpc-web=$(GRPC_WEB_PLUGIN_PATH) \
-  --grpc-web_out=out=$(OUT_DIR)/echo.grpc.pb.js,mode=grpcwebtext:. ./echo.proto
+  --grpc-web_out=import_style=closure,mode=grpcwebtext:. ./echo.proto
 
 install:
 	mkdir -p $(HTML_DIR)/$(EXAMPLES_PATH)

--- a/net/grpc/gateway/examples/echo/commonjs-example/client.js
+++ b/net/grpc/gateway/examples/echo/commonjs-example/client.js
@@ -1,6 +1,6 @@
 const {EchoRequest,
        ServerStreamingEchoRequest} = require('./echo_pb.js');
-const {EchoServiceClient} = require('./echo_grpc_pb.js');
+const {EchoServiceClient} = require('./echo_grpc_web_pb.js');
 const {EchoApp} = require('../echoapp.js');
 const grpc = {};
 grpc.web = require('grpc-web');

--- a/net/grpc/gateway/examples/echo/tutorial.md
+++ b/net/grpc/gateway/examples/echo/tutorial.md
@@ -127,7 +127,8 @@ In the `--grpc-web_out` param above:
   - `mode` can be `grpcwebtext` (default) or `grpcweb`
   - `import_style` can be `closure` (default) or `commonjs`
 
-Our command generates the client stub in the file `echo_grpc_pb.js`.
+Our command generates the client stub, by default, to the file
+`echo_grpc_web_pb.js`.
 
 
 ## Write JS Client Code
@@ -136,7 +137,7 @@ Now you are ready to write some JS client code. Put this in a `client.js` file.
 
 ```js
 const {EchoRequest, EchoResponse} = require('./echo_pb.js'));
-const {EchoServiceClient} = require('./echo_grpc_pb.js');
+const {EchoServiceClient} = require('./echo_grpc_web_pb.js');
 
 var echoService = new EchoServiceClient('http://localhost:8080');
 

--- a/packages/grpc-web/README.md
+++ b/packages/grpc-web/README.md
@@ -47,7 +47,7 @@ $ protoc -I=$DIR echo.proto \
 4. Start using your generated client!
 
 ```js
-const {EchoServiceClient} = require('./generated/echo_grpc_pb.js');
+const {EchoServiceClient} = require('./generated/echo_grpc_web_pb.js');
 const {EchoRequest} = require('./generated/echo_pb.js');
 
 const client = new EchoServiceClient('localhost:8080');


### PR DESCRIPTION
Remove the need to pass the `out=` parameter to the `protoc-gen-grpc-web` protoc plugin. 