### PR TITLE
Add "strictDependencies" to suppress attribute of Bazel rule

### DIFF
--- a/bazel/closure_grpc_web_library.bzl
+++ b/bazel/closure_grpc_web_library.bzl
@@ -123,7 +123,8 @@ def _closure_grpc_web_library_impl(ctx):
 
   suppress = [
       "misplacedTypeAnnotation",
-      "unusedPrivateMembers"
+      "unusedPrivateMembers",
+      "strictDependencies",
   ]
 
   library = closure_js_library_impl(


### PR DESCRIPTION
Not suppressing this causes an error for a missing direct dependency
for the generated gRPC-Web library if a service returns a protobuf
message not declared in the same proto_library.