### PR TITLE
Support CommonJS style imports for closure_grpc_web_library

### DIFF
--- a/bazel/closure_grpc_web_library.bzl
+++ b/bazel/closure_grpc_web_library.bzl
@@ -158,7 +158,7 @@ closure_grpc_web_library = rule(
         ),
         "import_style": attr.string(
             default = "closure",
-            values = ["closure"],
+            values = ["closure", "commonjs"],
         ),
         "mode": attr.string(
             default = "grpcwebtext",


### PR DESCRIPTION
It's similar to how `closure_js_proto_library` supports different import styles

cc @oferb