### PR TITLE
Make "Quick" start quicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Try gRPC-Web and run a quick Echo example from the browser!
 From the repo root directory:
 
 ```sh
-$ docker-compose up echo-server envoy commonjs-client
+$ docker-compose pull prereqs common echo-server envoy commonjs-client
+$ docker-compose up -d echo-server envoy commonjs-client
 ```
 
 Open a browser tab, and go to:
@@ -31,6 +32,8 @@ Open a browser tab, and go to:
 ```
 http://localhost:8081/echotest.html
 ```
+
+To shutdown: `docker-compose down`.
 
 
 ## Runtime Library

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,28 +4,28 @@ services:
     build:
       context: ./
       dockerfile: ./net/grpc/gateway/docker/prereqs/Dockerfile
-    image: grpc-web:prereqs
+    image: grpcweb/prereqs
   common:
     build:
       context: ./
       dockerfile: ./net/grpc/gateway/docker/common/Dockerfile
     depends_on:
       - prereqs
-    image: grpc-web:common
+    image: grpcweb/common
   echo-server:
     build:
       context: ./
       dockerfile: ./net/grpc/gateway/docker/echo_server/Dockerfile
     depends_on:
       - common
-    image: grpc-web:echo-server
+    image: grpcweb/echo-server
     ports:
       - "9090:9090"
   envoy:
     build:
       context: ./
       dockerfile: ./net/grpc/gateway/docker/envoy/Dockerfile
-    image: grpc-web:envoy
+    image: grpcweb/envoy
     ports:
       - "8080:8080"
     links:
@@ -36,7 +36,7 @@ services:
       dockerfile: ./net/grpc/gateway/docker/nginx/Dockerfile
     depends_on:
       - common
-    image: grpc-web:nginx
+    image: grpcweb/nginx
     ports:
       - "8080:8080"
     links:
@@ -45,7 +45,7 @@ services:
     build:
       context: ./
       dockerfile: ./net/grpc/gateway/docker/grpcwebproxy/Dockerfile
-    image: grpc-web:grpcwebproxy
+    image: grpcweb/grpcwebproxy
     ports:
       - "8080:8080"
     links:
@@ -56,7 +56,7 @@ services:
       dockerfile: ./net/grpc/gateway/docker/commonjs_client/Dockerfile
     depends_on:
       - common
-    image: grpc-web:commonjs-client
+    image: grpcweb/commonjs-client
     ports:
       - "8081:8081"
   closure-client:
@@ -65,7 +65,7 @@ services:
       dockerfile: ./net/grpc/gateway/docker/closure_client/Dockerfile
     depends_on:
       - common
-    image: grpc-web:closure-client
+    image: grpcweb/closure-client
     ports:
       - "80:80"
   ts-client:
@@ -74,7 +74,7 @@ services:
       dockerfile: ./net/grpc/gateway/docker/ts_client/Dockerfile
     depends_on:
       - common
-    image: grpc-web:ts-client
+    image: grpcweb/ts-client
     ports:
       - "8082:8082"
   binary-client:
@@ -83,6 +83,6 @@ services:
       dockerfile: ./net/grpc/gateway/docker/binary_client/Dockerfile
     depends_on:
       - common
-    image: grpc-web:binary-client
+    image: grpcweb/binary-client
     ports:
       - "8081:8081"

--- a/net/grpc/gateway/docker/binary_client/Dockerfile
+++ b/net/grpc/gateway/docker/binary_client/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpc-web:common
+FROM grpcweb/common
 
 ARG EXAMPLE_DIR=/github/grpc-web/net/grpc/gateway/examples/echo
 

--- a/net/grpc/gateway/docker/closure_client/Dockerfile
+++ b/net/grpc/gateway/docker/closure_client/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpc-web:common
+FROM grpcweb/common
 
 RUN cd /github/grpc-web && \
   curl https://dl.google.com/closure-compiler/compiler-latest.zip \

--- a/net/grpc/gateway/docker/common/Dockerfile
+++ b/net/grpc/gateway/docker/common/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpc-web:prereqs
+FROM grpcweb/prereqs
 
 COPY . /github/grpc-web
 

--- a/net/grpc/gateway/docker/commonjs_client/Dockerfile
+++ b/net/grpc/gateway/docker/commonjs_client/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpc-web:common
+FROM grpcweb/common
 
 ARG EXAMPLE_DIR=/github/grpc-web/net/grpc/gateway/examples/echo
 

--- a/net/grpc/gateway/docker/echo_server/Dockerfile
+++ b/net/grpc/gateway/docker/echo_server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpc-web:common
+FROM grpcweb/common
 
 RUN cd /github/grpc-web && \
   make echo_server

--- a/net/grpc/gateway/docker/nginx/Dockerfile
+++ b/net/grpc/gateway/docker/nginx/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpc-web:common
+FROM grpcweb/common
 
 RUN cd /github/grpc-web-base/net/grpc/gateway/examples/echo && \
   sed -i 's/localhost:9090/echo-server:9090/g' nginx.conf

--- a/net/grpc/gateway/docker/ts_client/Dockerfile
+++ b/net/grpc/gateway/docker/ts_client/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpc-web:common
+FROM grpcweb/common
 
 ARG EXAMPLE_DIR=/github/grpc-web/net/grpc/gateway/examples/echo
 

--- a/net/grpc/gateway/examples/echo/README.md
+++ b/net/grpc/gateway/examples/echo/README.md
@@ -26,7 +26,7 @@ This step compiles gRPC and Protobuf, and serves as the base docker image for
 the subsequent docker images.
 
 ```sh
-$ docker build -t grpc-web:prereqs \
+$ docker build -t grpcweb/prereqs \
   -f net/grpc/gateway/docker/prereqs/Dockerfile .
 ```
 
@@ -36,9 +36,9 @@ This compiles the gRPC backend server, written in C++, and listens on port
 9090.
 
 ```sh
-$ docker build -t grpc-web:echo-server \
+$ docker build -t grpcweb/echo-server \
   -f net/grpc/gateway/docker/echo_server/Dockerfile .
-$ docker run -d -p 9090:9090 --name echo-server grpc-web:echo-server
+$ docker run -d -p 9090:9090 --name echo-server grpcweb/echo-server
 ```
 
 ## Run the Envoy proxy
@@ -47,9 +47,9 @@ This step runs the Envoy proxy, and listens on port 8080. Any gRPC-Web browser
 requests will be forwarded to port 9090.
 
 ```sh
-$ docker build -t grpc-web:envoy \
+$ docker build -t grpcweb/envoy \
   -f net/grpc/gateway/docker/envoy/Dockerfile .
-$ docker run -d -p 8080:8080 --link echo-server:echo-server grpc-web:envoy
+$ docker run -d -p 8080:8080 --link echo-server:echo-server grpcweb/envoy
 ```
 
 ## Serve static JS/HTML contents
@@ -58,9 +58,9 @@ This steps compiles the front-end gRPC-Web client into a static .JS file, and
 we use a simple server to serve up the JS/HTML static contents.
 
 ```sh
-$ docker build -t grpc-web:closure-client \
+$ docker build -t grpcweb/closure-client \
   -f net/grpc/gateway/docker/closure_client/Dockerfile .
-$ docker run -d -p 80:80 grpc-web:closure-client
+$ docker run -d -p 80:80 grpcweb/closure-client
 ```
 
 ## Run the example from your browser

--- a/scripts/kokoro.sh
+++ b/scripts/kokoro.sh
@@ -53,5 +53,5 @@ source ./scripts/test-proxy.sh
 docker-compose down
 
 # Run unit tests from npm package
-docker run --rm grpc-web:common /bin/bash \
+docker run --rm grpcweb/common /bin/bash \
   /github/grpc-web/scripts/docker-run-tests.sh


### PR DESCRIPTION
Fixes #261 

Now all the relevant docker images have been uploaded to Docker. User can now just do a `pull` instead of having to `build` the docker images to launch the example.

```
$ docker-compose pull prereqs common echo-server envoy commonjs-client
$ docker-compose up -d echo-server envoy commonjs-client
```

Well, `pull` currently is still kinda slow because the image size is pretty large. Will look into reducing that soon.