### PR TITLE
Document how to prevent Envoy to timeout streaming

### DIFF
--- a/net/grpc/gateway/examples/helloworld/README.md
+++ b/net/grpc/gateway/examples/helloworld/README.md
@@ -112,7 +112,9 @@ static_resources:
               domains: ["*"]
               routes:
               - match: { prefix: "/" }
-                route: { cluster: greeter_service }
+                route:
+                  cluster: greeter_service
+                  max_grpc_timeout: 0s
               cors:
                 allow_origin:
                 - "*"

--- a/net/grpc/gateway/examples/helloworld/envoy.yaml
+++ b/net/grpc/gateway/examples/helloworld/envoy.yaml
@@ -21,7 +21,9 @@ static_resources:
               domains: ["*"]
               routes:
               - match: { prefix: "/" }
-                route: { cluster: greeter_service }
+                route:
+                  cluster: greeter_service
+                  max_grpc_timeout: 0s
               cors:
                 allow_origin:
                 - "*"


### PR DESCRIPTION
Fixes #309.

The example is missing this option, so all streaming calls get terminated after 15 seconds, if there is no message sent.