### PR TITLE
Show how deadline can be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,22 @@ stream.on('end', function(end) {
 You can find a more in-depth tutorial from
 [this page](https://github.com/grpc/grpc-web/blob/master/net/grpc/gateway/examples/echo/tutorial.md).
 
+## Setting Deadline
+
+You can set a deadline for your RPC by setting a `deadline` header. The value
+should be a Unix timestamp, in milliseconds.
+
+```js
+var deadline = new Date();
+deadline.setSeconds(deadline.getSeconds() + 1);
+
+client.sayHelloAfterDelay(request, {deadline: deadline.getTime()},
+  (err, response) => {
+    // err will be populated if the RPC exceeds the deadline
+    ...
+  });
+```
+
 ## TypeScript Support
 
 The `grpc-web` module can now be imported as a TypeScript module. This is
@@ -281,8 +297,9 @@ $ docker-compose up -d node-server grpcwebproxy binary-client
 Big thanks to the following contributors for making significant contributions to
 this project!
 
-* [zaucy](https://github.com/zaucy)
-* [yannic](https://github.com/yannic)
+* [zaucy](https://github.com/zaucy): NPM package, CommonJS
+* [yannic](https://github.com/yannic): Bazel
+* [mitar](https://github.com/mitar): Codegen Plugin
 
 
 [Hello World Guide]:https://github.com/grpc/grpc-web/blob/master/net/grpc/gateway/examples/helloworld/

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -95,14 +95,7 @@ GrpcWebClientBase.prototype.rpcCall = function(
   });
 
   xhr.headers.addAll(metadata);
-  if (this.format_ == "text") {
-    xhr.headers.set('Content-Type', 'application/grpc-web-text');
-    xhr.headers.set('Accept', 'application/grpc-web-text');
-  } else {
-    xhr.headers.set('Content-Type', 'application/grpc-web+proto');
-  }
-  xhr.headers.set('X-User-Agent', 'grpc-web-javascript/0.1');
-  xhr.headers.set('X-Grpc-Web', '1');
+  this.processHeaders_(xhr);
   if (this.suppressCorsPreflight_) {
     var headerObject = xhr.headers.toObject();
     xhr.headers.clear();
@@ -135,14 +128,7 @@ GrpcWebClientBase.prototype.serverStreaming = function(
   stream.setResponseDeserializeFn(methodInfo.responseDeserializeFn);
 
   xhr.headers.addAll(metadata);
-  if (this.format_ == "text") {
-    xhr.headers.set('Content-Type', 'application/grpc-web-text');
-    xhr.headers.set('Accept', 'application/grpc-web-text');
-  } else {
-    xhr.headers.set('Content-Type', 'application/grpc-web+proto');
-  }
-  xhr.headers.set('X-User-Agent', 'grpc-web-javascript/0.1');
-  xhr.headers.set('X-Grpc-Web', '1');
+  this.processHeaders_(xhr);
   if (this.suppressCorsPreflight_) {
     var headerObject = xhr.headers.toObject();
     xhr.headers.clear();
@@ -195,6 +181,30 @@ GrpcWebClientBase.prototype.encodeRequest_ = function(serialized) {
 };
 
 
+
+/**
+ * @private
+ * @param {!XhrIo} xhr The xhr object
+ */
+GrpcWebClientBase.prototype.processHeaders_ = function(xhr) {
+  if (this.format_ == "text") {
+    xhr.headers.set('Content-Type', 'application/grpc-web-text');
+    xhr.headers.set('Accept', 'application/grpc-web-text');
+  } else {
+    xhr.headers.set('Content-Type', 'application/grpc-web+proto');
+  }
+  xhr.headers.set('X-User-Agent', 'grpc-web-javascript/0.1');
+  xhr.headers.set('X-Grpc-Web', '1');
+  if (xhr.headers.containsKey('deadline')) {
+    var deadline = xhr.headers.get('deadline'); // in ms
+    var currentTime = (new Date()).getTime();
+    var timeout = Math.round(deadline - currentTime);
+    xhr.headers.remove('deadline');
+    if (timeout > 0) {
+      xhr.headers.set('grpc-timeout', timeout + 'm');
+    }
+  }    
+};
 
 /**
  * @private

--- a/net/grpc/gateway/examples/echo/envoy.yaml
+++ b/net/grpc/gateway/examples/echo/envoy.yaml
@@ -26,7 +26,7 @@ static_resources:
                 allow_origin:
                 - "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
                 expose_headers: custom-header-1,grpc-status,grpc-message
                 enabled: true

--- a/net/grpc/gateway/examples/helloworld/README.md
+++ b/net/grpc/gateway/examples/helloworld/README.md
@@ -119,7 +119,7 @@ static_resources:
                 allow_origin:
                 - "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
                 expose_headers: custom-header-1,grpc-status,grpc-message
                 enabled: true

--- a/net/grpc/gateway/examples/helloworld/client.js
+++ b/net/grpc/gateway/examples/helloworld/client.js
@@ -16,15 +16,39 @@
  *
  */
 
-const {HelloRequest, HelloReply} = require('./helloworld_pb.js');
+const {HelloRequest, RepeatHelloRequest,
+       HelloReply} = require('./helloworld_pb.js');
 const {GreeterClient} = require('./helloworld_grpc_web_pb.js');
 
 var client = new GreeterClient('http://' + window.location.hostname + ':8080',
                                null, null);
 
+// simple unary call
 var request = new HelloRequest();
 request.setName('World');
 
 client.sayHello(request, {}, (err, response) => {
   console.log(response.getMessage());
 });
+
+
+// server streaming call
+var streamRequest = new RepeatHelloRequest();
+streamRequest.setName('World');
+streamRequest.setCount(5);
+
+var stream = client.sayRepeatHello(streamRequest, {});
+stream.on('data', (response) => {
+  console.log(response.getMessage());
+});
+  
+
+// deadline exceeded
+var deadline = new Date();
+deadline.setSeconds(deadline.getSeconds() + 1);
+
+client.sayHelloAfterDelay(request, {deadline: deadline.getTime()},
+  (err, response) => {
+    console.log('Got error, code = ' + err.code +
+                ', message = ' + err.message);
+  });

--- a/net/grpc/gateway/examples/helloworld/envoy.yaml
+++ b/net/grpc/gateway/examples/helloworld/envoy.yaml
@@ -28,7 +28,7 @@ static_resources:
                 allow_origin:
                 - "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
                 expose_headers: custom-header-1,grpc-status,grpc-message
                 enabled: true

--- a/net/grpc/gateway/examples/helloworld/helloworld.proto
+++ b/net/grpc/gateway/examples/helloworld/helloworld.proto
@@ -18,10 +18,17 @@ package helloworld;
 
 service Greeter {
   rpc SayHello (HelloRequest) returns (HelloReply);
+  rpc SayRepeatHello (RepeatHelloRequest) returns (stream HelloReply);
+  rpc SayHelloAfterDelay (HelloRequest) returns (HelloReply);
 }
 
 message HelloRequest {
   string name = 1;
+}
+
+message RepeatHelloRequest {
+  string name = 1;
+  int32 count = 2;
 }
 
 message HelloReply {

--- a/net/grpc/gateway/examples/helloworld/node-client.js
+++ b/net/grpc/gateway/examples/helloworld/node-client.js
@@ -1,0 +1,61 @@
+var PROTO_PATH = __dirname + '/helloworld.proto';
+
+var async = require('async');
+var grpc = require('grpc');
+var protoLoader = require('@grpc/proto-loader');
+var packageDefinition = protoLoader.loadSync(
+    PROTO_PATH,
+    {keepCase: true,
+     longs: String,
+     enums: String,
+     defaults: true,
+     oneofs: true
+    });
+var protoDescriptor = grpc.loadPackageDefinition(packageDefinition)
+var helloworld = protoDescriptor.helloworld;
+var client = new helloworld.Greeter('localhost:9090',
+                                    grpc.credentials.createInsecure());
+
+function runSayHello(callback) {
+  client.sayHello({name: 'John'}, {}, (err, response) => {
+    console.log(response.message);
+    callback();
+  });
+}
+
+function runSayRepeatHello(callback) {
+  var stream = client.sayRepeatHello({name: 'John', count: 5}, {});
+  stream.on('data', (response) => {
+    console.log(response.message);
+  });
+  stream.on('end', () => {
+    callback();
+  });
+}
+
+function runSayHelloAfterDelay(callback) {
+  var deadline = new Date();
+  deadline.setSeconds(deadline.getSeconds() + 1);
+
+  client.sayHelloAfterDelay({name: 'John'}, {deadline: deadline.getTime()},
+    (err, response) => {
+      console.log('Got error, code = ' + err.code +
+                  ', message = ' + err.message);
+      callback();
+    });
+}
+
+/**
+ * Run all of the demos in order
+ */
+function main() {
+  async.series([
+    runSayHello,
+    runSayRepeatHello,
+    runSayHelloAfterDelay
+  ]);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/net/grpc/gateway/examples/helloworld/package.json
+++ b/net/grpc/gateway/examples/helloworld/package.json
@@ -4,9 +4,11 @@
   "description": "gRPC-Web simple example",
   "devDependencies": {
     "@grpc/proto-loader": "^0.3.0",
+    "async": "^1.5.2",
     "google-protobuf": "^3.6.1",
     "grpc": "^1.15.0",
     "grpc-web": "^0.4.0",
+    "lodash": "^4.6.1",
     "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0"
   }

--- a/net/grpc/gateway/examples/helloworld/server.js
+++ b/net/grpc/gateway/examples/helloworld/server.js
@@ -19,6 +19,8 @@
 var PROTO_PATH = __dirname + '/helloworld.proto';
 
 var grpc = require('grpc');
+var _ = require('lodash');
+var async = require('async');
 var protoLoader = require('@grpc/proto-loader');
 var packageDefinition = protoLoader.loadSync(
     PROTO_PATH,
@@ -32,8 +34,37 @@ var protoDescriptor = grpc.loadPackageDefinition(packageDefinition);
 var helloworld = protoDescriptor.helloworld;
 
 function doSayHello(call, callback) {
-  callback(null, {
-    message: 'Hello! ' + call.request.name
+  callback(null, {message: 'Hello! '+ call.request.name});
+}
+
+function doSayRepeatHello(call) {
+  var senders = [];
+  function sender(name) {
+    return (callback) => {
+      call.write({
+        message: 'Hey! ' + name
+      });
+      _.delay(callback, 500); // in ms
+    };
+  }
+  for (var i = 0; i < call.request.count; i++) {
+    senders[i] = sender(call.request.name + i);
+  }
+  async.series(senders, () => {
+    call.end();
+  });
+}
+
+function doSayHelloAfterDelay(call, callback) {
+  function dummy() {
+    return (cb) => {
+      _.delay(cb, 5000);
+    };
+  }
+  async.series([dummy()], () => {
+    callback(null, {
+      message: 'Hello! '+call.request.name
+    });
   });
 }
 
@@ -41,6 +72,8 @@ function getServer() {
   var server = new grpc.Server();
   server.addProtoService(helloworld.Greeter.service, {
     sayHello: doSayHello,
+    sayRepeatHello: doSayRepeatHello,
+    sayHelloAfterDelay: doSayHelloAfterDelay
   });
   return server;
 }


### PR DESCRIPTION
Show how we can set a `deadline` header for each RPC. The value should be a Unix timestamp, in milliseconds. The format should be the same as a gRPC Node client.

```
var deadline = new Date();
deadline.setSeconds(deadline.getSeconds() + 1);

client.sayHelloAfterDelay(request, {deadline: deadline.getTime()},
  (err, response) => {
    // err will be populated if the RPC exceeds the deadline
    ...
  });
```