### PR TITLE
build instead of pull example prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ streaming example.
 From the repo root directory:
 
 ```sh
-$ docker-compose pull prereqs common node-server envoy commonjs-client
+$ docker-compose build prereqs common node-server envoy commonjs-client
 $ docker-compose up -d node-server envoy commonjs-client
 ```
 


### PR DESCRIPTION
Currently, if you pull the images, they are from https://hub.docker.com/u/grpcweb/ and are 6 weeks old:

```
PS C:\Users\taggac\rs\grpc-web> docker images
REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
grpcweb/commonjs-client   latest              ebbf4af094ed        6 weeks ago         4.79GB
grpcweb/envoy             latest              9b442de7196d        6 weeks ago         136MB
grpcweb/common            latest              da37eeb78253        6 weeks ago         4.75GB
grpcweb/prereqs           latest              5731d4809e86        6 weeks ago         3.23GB
```

`node-server` also is not published there:

```
PS C:\Users\taggac\rs\grpc-web> docker-compose pull prereqs common node-server envoy commonjs-client
Pulling prereqs         ... done
Pulling common          ... done
Pulling node-server     ... error
Pulling envoy           ... done
Pulling commonjs-client ... done

ERROR: for node-server  pull access denied for grpcweb/node-server, repository does not exist or may require 'docker login'
ERROR: pull access denied for grpcweb/node-server, repository does not exist or may require 'docker login'
```

So the instructions would be valid if updated images were published, otherwise the readme should say to build it.