### PR TITLE
update typescript generation to work in strict mode

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -369,11 +369,11 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
     printer->Print(
         "client_: grpcWeb.AbstractClientBase;\n"
         "hostname_: string;\n"
-        "credentials_: {};\n"
-        "options_: { [s: string]: {}; };\n\n"
+        "credentials_: null | { [index: string]: string; };\n"
+        "options_: null | { [index: string]: string; };\n\n"
         "constructor (hostname: string,\n"
-        "             credentials: {},\n"
-        "             options: { [s: string]: {}; }) {\n");
+        "             credentials: null | { [index: string]: string; },\n"
+        "             options: null | { [index: string]: string; }) {\n");
     printer->Indent();
     printer->Print("if (!options) options = {};\n");
     if (vars["mode"] == GetModeVar(Mode::GRPCWEB)) {
@@ -466,8 +466,8 @@ void PrintGrpcWebDtsFile(Printer* printer, const FileDescriptor* file) {
     printer->Indent();
     printer->Print(
         "constructor (hostname: string,\n"
-        "             credentials: {},\n"
-        "             options: { [s: string]: {}; });\n\n");
+        "             credentials: null | { [index: string]: string; },\n"
+        "             options: null | { [index: string]: string; });\n\n");
     for (int method_index = 0; method_index < service->method_count();
          ++method_index) {
       const MethodDescriptor* method = service->method(method_index);
@@ -482,7 +482,8 @@ void PrintGrpcWebDtsFile(Printer* printer, const FileDescriptor* file) {
                          "request: $input_type$,\n"
                          "metadata: grpcWeb.Metadata\n");
           printer->Outdent();
-          printer->Print("): grpcWeb.ClientReadableStream;\n\n");
+          printer->Print(vars,
+                         "): grpcWeb.ClientReadableStream<$output_type$>;\n\n");
         } else {
           printer->Print(vars, "$js_method_name$(\n");
           printer->Indent();
@@ -492,7 +493,8 @@ void PrintGrpcWebDtsFile(Printer* printer, const FileDescriptor* file) {
                          "callback: (err: grpcWeb.Error,\n"
                          "           response: $output_type$) => void\n");
           printer->Outdent();
-          printer->Print("): grpcWeb.ClientReadableStream;\n\n");
+          printer->Print(vars,
+                         "): grpcWeb.ClientReadableStream<$output_type$>;\n\n");
         }
       }
     }

--- a/net/grpc/gateway/examples/echo/ts-example/client.ts
+++ b/net/grpc/gateway/examples/echo/ts-example/client.ts
@@ -101,9 +101,8 @@ class EchoApp {
     request.setMessageCount(count);
     request.setMessageInterval(EchoApp.INTERVAL);
 
-    const stream: grpcWeb.ClientReadableStream =
-        this.echoService_.serverStreamingEcho(
-            request, {'custom-header-1': 'value1'});
+    const stream = this.echoService_.serverStreamingEcho(
+        request, {'custom-header-1': 'value1'});
     const self = this;
     stream.on('data', (response: ServerStreamingEchoResponse) => {
       EchoApp.addRightMessage(response.getMessage());

--- a/net/grpc/gateway/examples/echo/ts-example/tsconfig.json
+++ b/net/grpc/gateway/examples/echo/ts-example/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
-    "noImplicitAny": true,
+    "strict": true,
     "allowJs": true,
     "outDir": "./dist",
     "types": ["node"],

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -3,31 +3,37 @@ declare module "grpc-web" {
   export interface Metadata { [s: string]: string; }
 
   export namespace AbstractClientBase {
-    class MethodInfo {
-      constructor (responseType: {},
-                   requestSerializeFn: (request: {}) => {},
-                   responseDeserializeFn: (bytes: {}) => {});
+    class MethodInfo<Request, Response> {
+      constructor (responseType: new () => Response,
+                   requestSerializeFn: (request: Request) => {},
+                   responseDeserializeFn: (bytes: {}) => Response);
     }
   }
 
   export class AbstractClientBase {
-    rpcCall (method: string,
-             request: {},
+    rpcCall<Request, Response> (method: string,
+             request: Request,
              metadata: Metadata,
-             methodInfo: AbstractClientBase.MethodInfo,
-             callback: (err: Error, response: {}) => void
-            ): ClientReadableStream;
+             methodInfo: AbstractClientBase.MethodInfo<Request, Response>,
+             callback: (err: Error, response: Response) => void
+            ): ClientReadableStream<Response>;
 
     serverStreaming (method: string,
-                     request: {},
+                     request: Request,
                      metadata: Metadata,
-                     methodInfo: AbstractClientBase.MethodInfo
-                    ): ClientReadableStream;
+                     methodInfo: AbstractClientBase.MethodInfo<Request, Response>
+                    ): ClientReadableStream<Response>;
   }
 
-  export class ClientReadableStream {
-    on (type: string,
-        callback: (...args: Array<{}>) => void): ClientReadableStream;
+  export class ClientReadableStream<Response> {
+    on (type: "error",
+        callback: (err: Error) => void): ClientReadableStream<Response>;
+    on (type: "status",
+        callback: (status: Status) => void): ClientReadableStream<Response>;
+    on (type: "data",
+        callback: (response: Response) => void): ClientReadableStream<Response>;
+    on (type: "end",
+        callback: () => void): ClientReadableStream<Response>;
     cancel (): void;
   }
 


### PR DESCRIPTION
The changes in this PR fixes the issues brought up in #279.

The problem is that in typescripts strict mode, the type `{}` only matches empty objects ex `const someVar = {}`, and not anything else.

The following changes are made:

1. update `tsconfig.json` to use `strict`
2. update `MethodInfo`/`AbstractClientBase`/`ClientReadableStream` to be generic over `Request` and `Response` types
3. update `ClientReadableStream.on` to have correct `callback` type depending on `type` argument
4. update generated clients to allow passing of `null` as `credentials` and `options`

I could not figure out where `credentials` and `options` are used so I could not figure out the correct types. If you could point me in the right direction that would be great! :)