### PR TITLE
 Add a max grpc timeout to the echo example. 

### DIFF
--- a/net/grpc/gateway/examples/echo/envoy.yaml
+++ b/net/grpc/gateway/examples/echo/envoy.yaml
@@ -21,7 +21,9 @@ static_resources:
               domains: ["*"]
               routes:
               - match: { prefix: "/" }
-                route: { cluster: echo_service }
+                route:
+                  cluster: echo_service
+                  max_grpc_timeout: 0s
               cors:
                 allow_origin:
                 - "*"

--- a/net/grpc/gateway/examples/echo/tutorial.md
+++ b/net/grpc/gateway/examples/echo/tutorial.md
@@ -135,7 +135,7 @@ Our command generates the client stub, by default, to the file
 Now you are ready to write some JS client code. Put this in a `client.js` file.
 
 ```js
-const {EchoRequest, EchoResponse} = require('./echo_pb.js'));
+const {EchoRequest, EchoResponse} = require('./echo_pb.js');
 const {EchoServiceClient} = require('./echo_grpc_web_pb.js');
 
 var echoService = new EchoServiceClient('http://localhost:8080');

--- a/net/grpc/gateway/examples/echo/tutorial.md
+++ b/net/grpc/gateway/examples/echo/tutorial.md
@@ -67,7 +67,9 @@ this:
               domains: ["*"]
               routes:
               - match: { prefix: "/" }
-                route: { cluster: echo_service }
+                route:
+                  cluster: echo_service
+                  max_grpc_timeout: 0s
           http_filters:
           - name: envoy.grpc_web
           - name: envoy.router


### PR DESCRIPTION
When a beginner continues with the example code to set up a streaming service, streams will be interrupted for no apparant reason after ~14 seconds. 
This makes sure streams will stay open.