### PR TITLE
Support grpc_ssl_target_name_override for grpc-web nginx gateway

### DIFF
--- a/net/grpc/gateway/backend/grpc_backend.cc
+++ b/net/grpc/gateway/backend/grpc_backend.cc
@@ -91,8 +91,8 @@ GrpcBackend::~GrpcBackend() {
 
 grpc_channel* GrpcBackend::CreateChannel() {
   return Runtime::Get().GetBackendChannel(
-      address_, use_shared_channel_pool_, ssl_, ssl_pem_root_certs_,
-      ssl_pem_private_key_, ssl_pem_cert_chain_);
+      address_, use_shared_channel_pool_, ssl_, ssl_target_override_,
+      ssl_pem_root_certs_, ssl_pem_private_key_, ssl_pem_cert_chain_);
 }
 
 grpc_call* GrpcBackend::CreateCall() {

--- a/net/grpc/gateway/backend/grpc_backend.h
+++ b/net/grpc/gateway/backend/grpc_backend.h
@@ -50,6 +50,9 @@ class GrpcBackend : public Backend {
     use_shared_channel_pool_ = use_shared_channel_pool;
   }
   void set_ssl(bool ssl) { ssl_ = ssl; }
+  void set_ssl_target_override(const string& ssl_target_override) {
+    ssl_target_override_ = ssl_target_override;
+  }
   void set_ssl_pem_root_certs(const string& ssl_pem_root_certs) {
     ssl_pem_root_certs_ = ssl_pem_root_certs;
   }
@@ -83,6 +86,8 @@ class GrpcBackend : public Backend {
   bool use_shared_channel_pool_;
   // True if ssl should be used.
   bool ssl_;
+  // The GRPC SSL target override.
+  string ssl_target_override_;
   // The file location which contains the root certs in pem format.
   string ssl_pem_root_certs_;
   // The file location which contains the client private key in pem format.

--- a/net/grpc/gateway/frontend/nginx_http_frontend.cc
+++ b/net/grpc/gateway/frontend/nginx_http_frontend.cc
@@ -86,6 +86,9 @@ ngx_int_t grpc_gateway_handler(ngx_http_request_t *r) {
   std::string backend_host(reinterpret_cast<char *>(r->host_start),
                            r->host_end - r->host_start);
   std::string backend_method(reinterpret_cast<char *>(r->uri.data), r->uri.len);
+  std::string backend_ssl_target_name_override(
+      reinterpret_cast<char *>(mlcf->grpc_ssl_target_name_override.data),
+      mlcf->grpc_ssl_target_name_override.len);
   std::string backend_ssl_pem_root_certs(
       reinterpret_cast<char *>(mlcf->grpc_ssl_pem_root_certs.data),
       mlcf->grpc_ssl_pem_root_certs.len);
@@ -106,7 +109,8 @@ ngx_int_t grpc_gateway_handler(ngx_http_request_t *r) {
   context->frontend = grpc::gateway::Runtime::Get().CreateNginxFrontend(
       r, backend_address, backend_host, backend_method,
       mlcf->grpc_channel_reuse, mlcf->grpc_client_liveness_detection_interval,
-      mlcf->grpc_ssl, backend_ssl_pem_root_certs, backend_ssl_pem_private_key,
+      mlcf->grpc_ssl, backend_ssl_target_name_override,
+      backend_ssl_pem_root_certs, backend_ssl_pem_private_key,
       backend_ssl_pem_cert_chain);
   ngx_http_set_ctx(r, context, grpc_gateway_module);
   ngx_pool_cleanup_t *http_cleanup =

--- a/net/grpc/gateway/runtime/runtime.h
+++ b/net/grpc/gateway/runtime/runtime.h
@@ -61,7 +61,8 @@ class Runtime {
       const string &host, const string &backend_method,
       const ngx_flag_t &channel_reuse,
       const ngx_msec_t &client_liveness_detection_interval,
-      const ngx_flag_t &backend_ssl, const string &backend_ssl_pem_root_certs,
+      const ngx_flag_t &backend_ssl, const string &backend_ssl_target_override,
+      const string &backend_ssl_pem_root_certs,
       const string &backend_ssl_pem_private_key,
       const string &backend_ssl_pem_cert_chain);
 
@@ -74,6 +75,7 @@ class Runtime {
   // channel if needed.
   grpc_channel *GetBackendChannel(const std::string &backend_address,
                                   bool use_shared_channel_pool, bool ssl,
+                                  const std::string &ssl_target_override,
                                   const std::string &ssl_pem_root_certs,
                                   const std::string &ssl_pem_private_key,
                                   const std::string &ssl_pem_cert_chain);


### PR DESCRIPTION
Support `grpc_ssl_target_name_override` for grpc-web nginx gateway