### PR TITLE
Fix the method name clashes for generated commonjs files 

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -669,7 +669,7 @@ void PrintMethodInfo(Printer* printer, std::map<string, string> vars) {
       " *   !proto.$in$,\n"
       " *   !proto.$out$>}\n"
       " */\n"
-      "const methodInfo_$method_name$ = "
+      "const methodInfo_$service_name$_$method_name$ = "
       "new grpc.web.AbstractClientBase.MethodInfo(\n");
   printer->Indent();
   printer->Print(
@@ -723,7 +723,7 @@ void PrintUnaryCall(Printer* printer, std::map<string, string> vars) {
       vars,
       "request,\n"
       "metadata,\n"
-      "methodInfo_$method_name$,\n"
+      "methodInfo_$service_name$_$method_name$,\n"
       "callback);\n");
   printer->Outdent();
   printer->Outdent();
@@ -793,7 +793,7 @@ void PrintServerStreamingCall(Printer* printer, std::map<string, string> vars) {
       vars,
       "request,\n"
       "metadata,\n"
-      "methodInfo_$method_name$);\n");
+      "methodInfo_$service_name$_$method_name$);\n");
   printer->Outdent();
   printer->Outdent();
   printer->Outdent();


### PR DESCRIPTION
This PR is related to #346.
When same the same proto file defines the same service name twice.

**Example - test.proto**
```
service Random
{
    rpc echo(google.protobuf.Empty) returns (stream SomeMessage) {}
}
service Random2
{
    rpc echo(google.protobuf.Empty) returns (stream SomeMessageTwo) {}
}
```
It will define the below method twice in the grpc_web_pb.js files which cause a error on run time
```
const methodInfo_echo = new grpc ....... 
```
