### PR TITLE
Fix response header value with colon

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -195,10 +195,10 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
     }
     var responseHeaders = self.xhr_.getResponseHeaders();
     if (GRPC_STATUS in responseHeaders &&
-        responseHeaders[GRPC_STATUS] != StatusCode.OK) {
+        Number(self.xhr_.getResponseHeader(GRPC_STATUS)) != StatusCode.OK) {
       self.onErrorCallback_({
-        code: Number(responseHeaders[GRPC_STATUS]),
-        message: responseHeaders[GRPC_STATUS_MESSAGE]
+        code: Number(self.xhr_.getResponseHeader(GRPC_STATUS)),
+        message: self.xhr_.getResponseHeader(GRPC_STATUS_MESSAGE)
       });
     }
   });


### PR DESCRIPTION
Fixes #318.

Very strange, let's say we have this response header `grpc-message: Foo: Bar` sent back from gRPC backend service, and thru Envoy, from the browser console, the header value apparently was sent back properly.

But, if I call `xhr.getResponseHeaders()` to get the whole bag of response headers, one of the key:value pair was `grpc-message: Foo`.

OTOH, if I call `xhr.getResponseHeader('grpc-message')`, I get `Foo: Bar` back properly.

I couldn't find a bug from Chrome or Closure to report this strange behavior with `xhr.getResponseHeaders()`.

Also OTOH, I cannot find any HTTP spec that said that http header value cannot have a colon in it. So apparently it's OK to have header value that has a colon in it.