### PR TITLE
update examples to use addService

### DIFF
--- a/net/grpc/gateway/examples/echo/node-server/server.js
+++ b/net/grpc/gateway/examples/echo/node-server/server.js
@@ -95,7 +95,7 @@ function doServerStreamingEcho(call) {
  */
 function getServer() {
   var server = new grpc.Server();
-  server.addProtoService(echo.EchoService.service, {
+  server.addService(echo.EchoService.service, {
     echo: doEcho,
     echoAbort: doEchoAbort,
     serverStreamingEcho: doServerStreamingEcho,

--- a/net/grpc/gateway/examples/helloworld/README.md
+++ b/net/grpc/gateway/examples/helloworld/README.md
@@ -66,7 +66,7 @@ function doSayHello(call, callback) {
 
 function getServer() {
   var server = new grpc.Server();
-  server.addProtoService(helloworld.Greeter.service, {
+  server.addService(helloworld.Greeter.service, {
     sayHello: doSayHello,
   });
   return server;

--- a/net/grpc/gateway/examples/helloworld/server.js
+++ b/net/grpc/gateway/examples/helloworld/server.js
@@ -84,7 +84,7 @@ function doSayHelloAfterDelay(call, callback) {
  */
 function getServer() {
   var server = new grpc.Server();
-  server.addProtoService(helloworld.Greeter.service, {
+  server.addService(helloworld.Greeter.service, {
     sayHello: doSayHello,
     sayRepeatHello: doSayRepeatHello,
     sayHelloAfterDelay: doSayHelloAfterDelay


### PR DESCRIPTION
small change to the samples now that the node server api has changed

link to api: https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/src/server.js#L948

the examples work with or without this change, but the change removes this warning message:
```
$ node server.js
(node:44083) DeprecationWarning: Server#addProtoService: Use Server#addService instead
```

complimentary PR submitted on docs repo:
https://github.com/grpc/grpc.github.io/pull/776