### PR TITLE
Make the bazel rules work with current rules_closure.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,10 +2,10 @@ workspace(name = "com_github_grpc_grpc_web")
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "4463509e8f86c9b7726b6b7c751132f0ca14f907cba00759b21f8577c2dcf710",
-    strip_prefix = "rules_closure-acad96981d76b60844bf815d03043619714839ad",
+    sha256 = "a8ea3251a6fd05eb3dbd05aa443a12b04cb88d80480d821bee453b18db97afaa",
+    strip_prefix = "rules_closure-8ec740d0b77ca1fb4914c857dc67ccc3f9cb3ed4",
     urls = [
-        "https://github.com/bazelbuild/rules_closure/archive/acad96981d76b60844bf815d03043619714839ad.zip",
+        "https://github.com/bazelbuild/rules_closure/archive/8ec740d0b77ca1fb4914c857dc67ccc3f9cb3ed4.zip",
     ],
 )
 

--- a/bazel/closure_grpc_web_library.bzl
+++ b/bazel/closure_grpc_web_library.bzl
@@ -4,7 +4,7 @@
 
 load(
     "@io_bazel_rules_closure//closure/compiler:closure_js_library.bzl",
-    "closure_js_library_impl",
+    "create_closure_js_library",
 )
 load(
     "@io_bazel_rules_closure//closure/private:defs.bzl",
@@ -124,22 +124,14 @@ def _closure_grpc_web_library_impl(ctx):
   suppress = [
       "misplacedTypeAnnotation",
       "unusedPrivateMembers",
-      "strictDependencies",
   ]
 
-  library = closure_js_library_impl(
-      actions = ctx.actions,
-      label = ctx.label,
-      workspace_name = ctx.workspace_name,
-
+  library = create_closure_js_library(
+      ctx = ctx,
       srcs = srcs,
       deps = deps,
-      testonly = ctx.attr.testonly,
       suppress = suppress,
       lenient = False,
-
-      closure_library_base = ctx.files._closure_library_base,
-      _ClosureWorker = ctx.executable._ClosureWorker,
   )
   return struct(
       exports = library.exports,

--- a/bazel/closure_grpc_web_library.bzl
+++ b/bazel/closure_grpc_web_library.bzl
@@ -8,8 +8,7 @@ load(
 )
 load(
     "@io_bazel_rules_closure//closure/private:defs.bzl",
-    "CLOSURE_WORKER_ATTR",
-    "CLOSURE_LIBRARY_BASE_ATTR",
+    "CLOSURE_JS_TOOLCHAIN_ATTRS",
     "unfurl",
 )
 load(
@@ -142,7 +141,7 @@ def _closure_grpc_web_library_impl(ctx):
 
 closure_grpc_web_library = rule(
     implementation = _closure_grpc_web_library_impl,
-    attrs = {
+    attrs = dict({
         "deps": attr.label_list(
             mandatory = True,
             providers = ["proto", "closure_js_library"],
@@ -157,10 +156,6 @@ closure_grpc_web_library = rule(
             default = "grpcwebtext",
             values = ["grpcwebtext", "grpcweb"],
         ),
-
-        # Required for closure_js_library_impl
-        "_ClosureWorker": CLOSURE_WORKER_ATTR,
-        "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
 
         # internal only
         "_protoc": attr.label(
@@ -185,5 +180,5 @@ closure_grpc_web_library = rule(
         "_grpc_web_grpcwebclientbase": attr.label(
             default = Label("//javascript/net/grpc/web:grpcwebclientbase"),
         ),
-    },
+    }, **CLOSURE_JS_TOOLCHAIN_ATTRS),
 )


### PR DESCRIPTION
[This commit](https://github.com/bazelbuild/rules_closure/commit/67c1337aa6348a395e47b5a100ceb412b2c69bd6 ) introduced a helper function for creating `closure_js_library`.