### PR TITLE
Added other tools required to build protoc to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ $ sudo make install-plugin
 
 If you don't already have `protoc` installed, you may have to do this first:
 
+On ubuntu:
+```sh
+apt install autoconf g++ libtool
+```
+On mac:
+```sh
+brew install autoconf automake libtool
+```
+
 ```sh
 $ ./scripts/init_submodules.sh
 $ cd third_party/grpc/third_party/protobuf


### PR DESCRIPTION
I needed to install autoconf and libtool and also added g++. It might not be obvious for some users just wanting to experiment with grpc web and suddenly have to compile a c/c++ program.