### PR TITLE
Optional metadata argument

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -494,14 +494,14 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Indent();
           printer->Print(vars,
                          "request: $input_type$,\n"
-                         "metadata: grpcWeb.Metadata) {\n");
+                         "metadata?: grpcWeb.Metadata) {\n");
           printer->Print(vars, "return this.client_.serverStreaming(\n");
           printer->Indent();
           printer->Print(vars,
                          "this.hostname_ +\n"
                          "  '/$package_dot$$service_name$/$method_name$',\n"
                          "request,\n"
-                         "metadata,\n"
+                         "metadata || {},\n"
                          "this.methodInfo$method_name$);\n");
           printer->Outdent();
           printer->Outdent();
@@ -511,7 +511,7 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Indent();
           printer->Print(vars,
                          "request: $input_type$,\n"
-                         "metadata: grpcWeb.Metadata,\n"
+                         "metadata?: grpcWeb.Metadata,\n"
                          "callback: (err: grpcWeb.Error,\n"
                          "           response: $output_type$) => void) {\n");
           printer->Print(vars, "return this.client_.rpcCall(\n");
@@ -520,7 +520,7 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
                          "this.hostname_ +\n"
                          "  '/$package_dot$$service_name$/$method_name$',\n"
                          "request,\n"
-                         "metadata,\n"
+                         "metadata || {},\n"
                          "this.methodInfo$method_name$,\n"
                          "callback);\n");
           printer->Outdent();
@@ -560,7 +560,7 @@ void PrintGrpcWebDtsClientClass(Printer* printer, const FileDescriptor* file, co
           printer->Indent();
           printer->Print(vars,
                          "request: $input_type$,\n"
-                         "metadata: grpcWeb.Metadata\n");
+                         "metadata?: grpcWeb.Metadata\n");
           printer->Outdent();
           printer->Print(vars,
                          "): grpcWeb.ClientReadableStream<$output_type$>;\n\n");
@@ -570,7 +570,7 @@ void PrintGrpcWebDtsClientClass(Printer* printer, const FileDescriptor* file, co
             printer->Indent();
             printer->Print(vars,
                            "request: $input_type$,\n"
-                           "metadata: grpcWeb.Metadata\n");
+                           "metadata?: grpcWeb.Metadata\n");
             printer->Outdent();
             printer->Print(vars,
                            "): Promise<$output_type$>;\n\n");
@@ -579,7 +579,7 @@ void PrintGrpcWebDtsClientClass(Printer* printer, const FileDescriptor* file, co
             printer->Indent();
             printer->Print(vars,
                            "request: $input_type$,\n"
-                           "metadata: grpcWeb.Metadata,\n"
+                           "metadata: grpcWeb.Metadata | undefined,\n"
                            "callback: (err: grpcWeb.Error,\n"
                            "           response: $output_type$) => void\n");
             printer->Outdent();
@@ -795,7 +795,7 @@ void PrintUnaryCall(Printer* printer, std::map<string, string> vars) {
       "/**\n"
       " * @param {!proto.$in$} request The\n"
       " *     request proto\n"
-      " * @param {!Object<string, string>} metadata User defined\n"
+      " * @param {Object<string, string>} metadata User defined\n"
       " *     call metadata\n"
       " * @param {function(?grpc.web.Error,"
       " ?proto.$out$)}\n"
@@ -820,7 +820,7 @@ void PrintUnaryCall(Printer* printer, std::map<string, string> vars) {
   printer->Print(
       vars,
       "request,\n"
-      "metadata,\n"
+      "metadata || {},\n"
       "methodInfo_$service_name$_$method_name$,\n"
       "callback);\n");
   printer->Outdent();
@@ -835,7 +835,7 @@ void PrintPromiseUnaryCall(Printer* printer,
                  "/**\n"
                  " * @param {!proto.$in$} request The\n"
                  " *     request proto\n"
-                 " * @param {!Object<string, string>} metadata User defined\n"
+                 " * @param {?Object<string, string>} metadata User defined\n"
                  " *     call metadata\n"
                  " * @return {!Promise<!proto.$out$>}\n"
                  " *     The XHR Node Readable Stream\n"
@@ -860,7 +860,7 @@ void PrintServerStreamingCall(Printer* printer, std::map<string, string> vars) {
       vars,
       "/**\n"
       " * @param {!proto.$in$} request The request proto\n"
-      " * @param {!Object<string, string>} metadata User defined\n"
+      " * @param {?Object<string, string>} metadata User defined\n"
       " *     call metadata\n"
       " * @return {!grpc.web.ClientReadableStream<!proto.$out$>}\n"
       " *     The XHR Node Readable Stream\n"


### PR DESCRIPTION
Cut down version of #389 allowing metadata argument to be optional in line with nodejs `grpc` interface.