### PR TITLE
Bazel rules: additional suppress options

### DIFF
--- a/bazel/closure_grpc_web_library.bzl
+++ b/bazel/closure_grpc_web_library.bzl
@@ -123,6 +123,9 @@ def _closure_grpc_web_library_impl(ctx):
   suppress = [
       "misplacedTypeAnnotation",
       "unusedPrivateMembers",
+      "reportUnknownTypes",
+      "strictDependencies",
+      "extraRequire",
   ]
 
   library = create_closure_js_library(


### PR DESCRIPTION
I had to add these suppress options in order to get a real-life generated service.grpc.js to compile with the Closure compiler.