### PR TITLE
Update README and simplify example to use prebuilt binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ standalone-proxy: package_static
 echo_server:
 	cd "$(ROOT_DIR)"/net/grpc/gateway/examples/echo && make echo_server
 
-client: plugin
+client:
 	cd "$(ROOT_DIR)"/net/grpc/gateway/examples/echo && make client
 
 install-example:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ streaming example.
 From the repo root directory:
 
 ```sh
-$ docker-compose pull prereqs common node-server envoy commonjs-client
-$ docker-compose up -d node-server envoy commonjs-client
+$ docker-compose pull
+$ docker-compose up
 ```
 
 Open a browser tab, and go to:
@@ -59,27 +59,20 @@ $ npm i grpc-web
 
 ## Code Generator Plugin
 
-You can compile the `protoc-gen-grpc-web` protoc plugin from this repo:
+You can download the `protoc-gen-grpc-web` protoc plugin from our
+[release](https://github.com/grpc/grpc-web/releases) page:
 
-```sh
-$ sudo make install-plugin
+If you don't already have `protoc` installed, you will have to download it
+first from [here](https://github.com/protocolbuffers/protobuf/releases).
+
+Make sure they are both executable and are discoverable from your PATH.
+
+For example, in MacOS, you can do:
+
 ```
-
-If you don't already have `protoc` installed, you may have to do this first:
-
-On ubuntu:
-```sh
-apt install autoconf g++ libtool
-```
-On mac:
-```sh
-brew install autoconf automake libtool
-```
-
-```sh
-$ ./scripts/init_submodules.sh
-$ cd third_party/grpc/third_party/protobuf
-$ ./autogen.sh && ./configure && make -j8 && sudo make install
+$ sudo mv ~/Downloads/protoc-gen-grpc-web-1.0.3-darwin-x86_64 \
+  /usr/local/bin/protoc-gen-grpc-web
+$ chmod +x /usr/local/bin/protoc-gen-grpc-web
 ```
 
 
@@ -292,14 +285,14 @@ $ docker-compose up -d node-server envoy commonjs-client
 An alternative is to build Nginx that comes with this repository.
 
 ```sh
-$ docker-compose up -d node-server nginx commonjs-client
+$ docker-compose -f advanced.yml up -d echo-server nginx closure-client
 ```
 
 You can also try this
 [gRPC-Web Go Proxy](https://github.com/improbable-eng/grpc-web/tree/master/go/grpcwebproxy).
 
 ```sh
-$ docker-compose up -d node-server grpcwebproxy binary-client
+$ docker-compose -f advanced.yml up -d node-server grpcwebproxy binary-client
 ```
 
 ## Acknowledgement

--- a/advanced.yml
+++ b/advanced.yml
@@ -1,0 +1,97 @@
+version: '3'
+services:
+  common:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/common/Dockerfile
+    image: grpcweb/common
+  prereqs:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/prereqs/Dockerfile
+    depends_on:
+      - common
+    image: grpcweb/prereqs
+  echo-server:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/echo_server/Dockerfile
+    depends_on:
+      - prereqs
+    image: grpcweb/echo-server
+    ports:
+      - "9090:9090"
+  node-server:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/node_server/Dockerfile
+    depends_on:
+      - common
+    image: grpcweb/node-server
+    ports:
+      - "9090:9090"
+  envoy:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/envoy/Dockerfile
+    image: grpcweb/envoy
+    ports:
+      - "8080:8080"
+    links:
+      - node-server
+  nginx:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/nginx/Dockerfile
+    depends_on:
+      - prereqs
+    image: grpcweb/nginx
+    ports:
+      - "8080:8080"
+    links:
+      - echo-server
+  grpcwebproxy:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/grpcwebproxy/Dockerfile
+    image: grpcweb/grpcwebproxy
+    ports:
+      - "8080:8080"
+    links:
+      - node-server
+  commonjs-client:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/commonjs_client/Dockerfile
+    depends_on:
+      - common
+    image: grpcweb/commonjs-client
+    ports:
+      - "8081:8081"
+  closure-client:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/closure_client/Dockerfile
+    depends_on:
+      - prereqs
+    image: grpcweb/closure-client
+    ports:
+      - "8081:8081"
+  ts-client:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/ts_client/Dockerfile
+    depends_on:
+      - prereqs
+    image: grpcweb/ts-client
+    ports:
+      - "8081:8081"
+  binary-client:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/binary_client/Dockerfile
+    depends_on:
+      - prereqs
+    image: grpcweb/binary-client
+    ports:
+      - "8081:8081"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,10 @@
 version: '3'
 services:
-  prereqs:
-    build:
-      context: ./
-      dockerfile: ./net/grpc/gateway/docker/prereqs/Dockerfile
-    image: grpcweb/prereqs
   common:
     build:
       context: ./
       dockerfile: ./net/grpc/gateway/docker/common/Dockerfile
-    depends_on:
-      - prereqs
     image: grpcweb/common
-  echo-server:
-    build:
-      context: ./
-      dockerfile: ./net/grpc/gateway/docker/echo_server/Dockerfile
-    depends_on:
-      - common
-    image: grpcweb/echo-server
-    ports:
-      - "9090:9090"
   node-server:
     build:
       context: ./
@@ -39,26 +23,6 @@ services:
       - "8080:8080"
     links:
       - node-server
-  nginx:
-    build:
-      context: ./
-      dockerfile: ./net/grpc/gateway/docker/nginx/Dockerfile
-    depends_on:
-      - common
-    image: grpcweb/nginx
-    ports:
-      - "8080:8080"
-    links:
-      - node-server
-  grpcwebproxy:
-    build:
-      context: ./
-      dockerfile: ./net/grpc/gateway/docker/grpcwebproxy/Dockerfile
-    image: grpcweb/grpcwebproxy
-    ports:
-      - "8080:8080"
-    links:
-      - node-server
   commonjs-client:
     build:
       context: ./
@@ -66,32 +30,5 @@ services:
     depends_on:
       - common
     image: grpcweb/commonjs-client
-    ports:
-      - "8081:8081"
-  closure-client:
-    build:
-      context: ./
-      dockerfile: ./net/grpc/gateway/docker/closure_client/Dockerfile
-    depends_on:
-      - common
-    image: grpcweb/closure-client
-    ports:
-      - "8081:8081"
-  ts-client:
-    build:
-      context: ./
-      dockerfile: ./net/grpc/gateway/docker/ts_client/Dockerfile
-    depends_on:
-      - common
-    image: grpcweb/ts-client
-    ports:
-      - "8081:8081"
-  binary-client:
-    build:
-      context: ./
-      dockerfile: ./net/grpc/gateway/docker/binary_client/Dockerfile
-    depends_on:
-      - common
-    image: grpcweb/binary-client
     ports:
       - "8081:8081"

--- a/net/grpc/gateway/docker/binary_client/Dockerfile
+++ b/net/grpc/gateway/docker/binary_client/Dockerfile
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpcweb/common
+FROM grpcweb/prereqs
 
 ARG EXAMPLE_DIR=/github/grpc-web/net/grpc/gateway/examples/echo
 
 RUN protoc -I=$EXAMPLE_DIR echo.proto \
---plugin=protoc-gen-grpc-web=\
-/github/grpc-web/javascript/net/grpc/web/protoc-gen-grpc-web \
 --js_out=import_style=commonjs:\
 $EXAMPLE_DIR/commonjs-example \
 --grpc-web_out=import_style=commonjs,mode=grpcweb:\
@@ -32,4 +30,5 @@ RUN cd $EXAMPLE_DIR/commonjs-example && \
   cp dist/main.js /var/www/html/dist
 
 EXPOSE 8081
-CMD ["nginx"]
+WORKDIR /var/www/html
+CMD ["python", "-m", "SimpleHTTPServer", "8081"]

--- a/net/grpc/gateway/docker/closure_client/Dockerfile
+++ b/net/grpc/gateway/docker/closure_client/Dockerfile
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpcweb/common
+FROM grpcweb/prereqs
+
+RUN apt-get -qq install -y \
+  default-jdk
 
 RUN cd /github/grpc-web && \
-  curl https://dl.google.com/closure-compiler/compiler-latest.zip \
+  curl -sS https://dl.google.com/closure-compiler/compiler-latest.zip \
   -o /github/grpc-web/compiler-latest.zip
 
 RUN cd /github/grpc-web && \
@@ -27,4 +30,5 @@ RUN cd /github/grpc-web && \
   make client && make install-example
 
 EXPOSE 8081
-CMD ["nginx"]
+WORKDIR /var/www/html
+CMD ["python", "-m", "SimpleHTTPServer", "8081"]

--- a/net/grpc/gateway/docker/common/Dockerfile
+++ b/net/grpc/gateway/docker/common/Dockerfile
@@ -12,25 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpcweb/prereqs
+FROM node:8-stretch
 
-COPY . /github/grpc-web
+RUN apt-get -qq update && apt-get -qq install -y \
+  unzip
 
-RUN cd /github/grpc-web && \
-  git checkout . && \
-  rm -rf third_party && \
-  git checkout third_party && \
-  git clean -f -d -x && \
-  ./scripts/init_submodules.sh
+RUN git clone https://github.com/grpc/grpc-web /github/grpc-web
 
-RUN cd /github/grpc-web && \
-  make install-plugin
+RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/\
+protoc-3.6.1-linux-x86_64.zip -o /tmp/protoc.zip && \
+  cd /tmp && \
+  unzip -qq protoc.zip && \
+  cp /tmp/bin/protoc /usr/local/bin/protoc
 
-RUN cd /github/grpc-web/packages/grpc-web && \
-  npm install && \
-  npm run build && \
-  npm link
+RUN curl -sSL https://github.com/grpc/grpc-web/releases/download/1.0.3/\
+protoc-gen-grpc-web-1.0.3-linux-x86_64 -o /usr/local/bin/protoc-gen-grpc-web && \
+  chmod +x /usr/local/bin/protoc-gen-grpc-web
 
-RUN cp /github/grpc-web/net/grpc/gateway/examples/echo/nginx_simple.conf \
-  /etc/nginx/nginx.conf && \
-  mkdir -p /var/www/html/dist
+RUN mkdir -p /var/www/html/dist

--- a/net/grpc/gateway/docker/commonjs_client/Dockerfile
+++ b/net/grpc/gateway/docker/commonjs_client/Dockerfile
@@ -24,10 +24,10 @@ $EXAMPLE_DIR/commonjs-example
 
 RUN cd $EXAMPLE_DIR/commonjs-example && \
   npm install && \
-  npm link grpc-web && \
   npx webpack && \
   cp echotest.html /var/www/html && \
   cp dist/main.js /var/www/html/dist
 
 EXPOSE 8081
-CMD ["nginx"]
+WORKDIR /var/www/html
+CMD ["python", "-m", "SimpleHTTPServer", "8081"]

--- a/net/grpc/gateway/docker/echo_server/Dockerfile
+++ b/net/grpc/gateway/docker/echo_server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpcweb/common
+FROM grpcweb/prereqs
 
 RUN cd /github/grpc-web && \
   make echo_server

--- a/net/grpc/gateway/docker/grpcwebproxy/Dockerfile
+++ b/net/grpc/gateway/docker/grpcwebproxy/Dockerfile
@@ -19,10 +19,10 @@ RUN apk add --no-cache curl git ca-certificates && \
 
 ARG VERSION=0.6.2
 
-RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+RUN curl -sS https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 RUN wget https://github.com/improbable-eng/grpc-web/archive/$VERSION.tar.gz
 RUN mkdir -p /go/src/github.com/improbable-eng/
-RUN tar -zxvf $VERSION.tar.gz -C /go/src/github.com/improbable-eng/
+RUN tar -zxf $VERSION.tar.gz -C /go/src/github.com/improbable-eng/
 RUN cd /go/src/github.com/improbable-eng && mv grpc-web-$VERSION grpc-web
 RUN cd /go/src/github.com/improbable-eng/grpc-web && \
   dep ensure --vendor-only && \

--- a/net/grpc/gateway/docker/nginx/Dockerfile
+++ b/net/grpc/gateway/docker/nginx/Dockerfile
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpcweb/common
+FROM grpcweb/prereqs
 
-RUN cd /github/grpc-web-base/net/grpc/gateway/examples/echo && \
-  sed -i 's/localhost:9090/node-server:9090/g' nginx.conf
+RUN apt-get -qq install -y \
+  zip
 
-RUN cd /github/grpc-web-base && \
+RUN cd /github/grpc-web/net/grpc/gateway/examples/echo && \
+  sed -i 's/localhost:9090/echo-server:9090/g' nginx.conf
+
+RUN cd /github/grpc-web && \
   make standalone-proxy
 
 EXPOSE 8080
-CMD ["/github/grpc-web-base/gConnector_static/nginx.sh"]
+CMD ["/github/grpc-web/gConnector_static/nginx.sh"]

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -12,35 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM grpcweb/common
 
 ARG MAKEFLAGS=-j8
 
-RUN apt-get update && apt-get install -y \
-  autoconf \
-  automake \
-  build-essential \
-  curl \
-  git \
-  default-jdk \
-  default-jre \
-  libtool \
-  libpcre3-dev \
-  libssl-dev \
-  make \
-  nginx \
-  zip
+COPY . /github/grpc-web
 
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-  apt-get install -y nodejs
-
-RUN git clone https://github.com/grpc/grpc-web /github/grpc-web-base
-
-RUN cd /github/grpc-web-base && \
+RUN cd /github/grpc-web && \
+  git checkout . && \
+  git clean -f -d -x && \
+  rm -rf third_party && \
+  git checkout third_party && \
   ./scripts/init_submodules.sh
 
-RUN cd /github/grpc-web-base/third_party/grpc && \
-  make && make install
+RUN cd /github/grpc-web/packages/grpc-web && \
+  npm install && \
+  npm run build && \
+  npm link
 
-RUN cd /github/grpc-web-base/third_party/grpc/third_party/protobuf && \
+RUN cd /github/grpc-web/third_party/grpc && \
   make install
+
+RUN cd /github/grpc-web/third_party/grpc/third_party/protobuf && \
+  make install
+
+RUN cd /github/grpc-web && \
+  make install-plugin

--- a/net/grpc/gateway/docker/protoc_plugin/Dockerfile
+++ b/net/grpc/gateway/docker/protoc_plugin/Dockerfile
@@ -16,7 +16,7 @@ FROM ubuntu:14.04
 
 ARG MAKEFLAGS=-j8
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get -qq update && apt-get -qq install -y \
   autoconf \
   automake \
   build-essential \

--- a/net/grpc/gateway/docker/ts_client/Dockerfile
+++ b/net/grpc/gateway/docker/ts_client/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpcweb/common
+FROM grpcweb/prereqs
 
 ARG EXAMPLE_DIR=/github/grpc-web/net/grpc/gateway/examples/echo
 
@@ -31,4 +31,5 @@ RUN cd $EXAMPLE_DIR/ts-example && \
   cp dist/main.js /var/www/html/dist
 
 EXPOSE 8081
-CMD ["nginx"]
+WORKDIR /var/www/html
+CMD ["python", "-m", "SimpleHTTPServer", "8081"]

--- a/net/grpc/gateway/examples/echo/Makefile
+++ b/net/grpc/gateway/examples/echo/Makefile
@@ -28,7 +28,7 @@ OUT_DIR = ./out
 PROTOBUF_PATH = third_party/grpc/third_party/protobuf
 GRPC_CPP_PLUGIN = grpc_cpp_plugin
 GRPC_CPP_PLUGIN_PATH ?= `which $(GRPC_CPP_PLUGIN)`
-GRPC_WEB_PLUGIN_PATH = $(ROOT_DIR)/$(JS_PATH)/protoc-gen-grpc-web
+GRPC_WEB_PLUGIN_PATH = /usr/local/bin/protoc-gen-grpc-web
 
 all: echo_server client package
 
@@ -83,9 +83,11 @@ proto-js:
   --js_out=$(JS_IMPORT_STYLE):$(OUT_DIR) \
   $(ROOT_DIR)/$(PROTOBUF_PATH)/src/google/protobuf/any.proto
 	$(PROTOC) -I=$(PROTOS_PATH)/protos \
+	-I=$(ROOT_DIR)/$(PROTOBUF_PATH)/src \
   --js_out=$(JS_IMPORT_STYLE):$(OUT_DIR) \
   $(PROTOS_PATH)/protos/stream_body.proto
 	$(PROTOC) -I=$(PROTOS_PATH)/protos \
+	-I=$(ROOT_DIR)/$(PROTOBUF_PATH)/src \
   --js_out=$(JS_IMPORT_STYLE):$(OUT_DIR) \
   $(PROTOS_PATH)/protos/pair.proto
 	$(PROTOC) -I=. --js_out=$(JS_IMPORT_STYLE):$(OUT_DIR) ./echo.proto

--- a/net/grpc/gateway/examples/helloworld/README.md
+++ b/net/grpc/gateway/examples/helloworld/README.md
@@ -216,23 +216,22 @@ And that's it! We have all the code ready. Let's run the example!
 
 To generate the protobuf messages and client service stub class from your
 `.proto` definitions, we need the `protoc` binary and the
-`protoc-gen-grpc-web` plugin. In the meantime, you will need to compile the
-latter yourself. We hope to improve and streamline the process in the near
-future.
+`protoc-gen-grpc-web` plugin.
 
-```sh
-$ git clone https://github.com/grpc/grpc-web
-$ cd grpc-web
-$ sudo make install-plugin
+You can download the `protoc-gen-grpc-web` protoc plugin from our
+[release](https://github.com/grpc/grpc-web/releases) page:
+
+If you don't already have `protoc` installed, you will have to download it
+first from [here](https://github.com/protocolbuffers/protobuf/releases).
+
+Make sure they are both executable and are discoverable from your PATH.
+
+For example, in MacOS, you can do:
+
 ```
-
-If you do not already have `protoc` installed, you may have to do this first:
-
-```sh
-$ ./scripts/init_submodules.sh
-$ cd third_party/grpc/third_party/protobuf
-$ ./autogen.sh && ./configure && make -j8
-$ sudo make install
+$ sudo mv ~/Downloads/protoc-gen-grpc-web-1.0.3-darwin-x86_64 \
+  /usr/local/bin/protoc-gen-grpc-web
+$ chmod +x /usr/local/bin/protoc-gen-grpc-web
 ```
 
 When you have both `protoc` and `protoc-gen-grpc-web` installed, you can now

--- a/packages/grpc-web/README.md
+++ b/packages/grpc-web/README.md
@@ -27,12 +27,26 @@ This example is using the `echo.proto` file from the
 $ npm i grpc-web
 ```
 
- 2. Compile the `protoc-gen-grpc-web` protoc plugin.
+ 2. Download `protoc` and the `protoc-gen-grpc-web` protoc plugin.
 
-```sh
-$ git clone https://github.com/grpc/grpc-web
-$ cd grpc-web && sudo make install-plugin
+You can download the `protoc` binary from the official
+[protocolbuffers](https://github.com/protocolbuffers/protobuf/releases)
+release page.
+
+You can download the `protoc-gen-grpc-web` protoc plugin from our Github
+[release](https://github.com/grpc/grpc-web/releases) page.
+
+
+Make sure they are both executable and are discoverable from your PATH.
+
+For example, in MacOS, you can do:
+
 ```
+$ sudo mv ~/Downloads/protoc-gen-grpc-web-1.0.3-darwin-x86_64 \
+  /usr/local/bin/protoc-gen-grpc-web
+$ chmod +x /usr/local/bin/protoc-gen-grpc-web
+```
+
 
  3. Generate your proto messages and the service client stub classes with
 `protoc` and the `protoc-gen-grpc-web` plugin. You can set the

--- a/scripts/kokoro.sh
+++ b/scripts/kokoro.sh
@@ -28,7 +28,7 @@ do
 done
 
 # Build all relevant docker images. They should all build successfully.
-docker-compose build
+docker-compose -f advanced.yml build
 
 # Run all bazel unit tests
 BAZEL_VERSION=0.19.1
@@ -39,6 +39,7 @@ $HOME/bin/bazel version
 $HOME/bin/bazel test \
   //javascript/net/grpc/web/... \
   //net/grpc/gateway/examples/...
+rm ./bazel-"${BAZEL_VERSION}"-installer-linux-x86_64.sh
 
 # Build the grpc-web npm package
 cd packages/grpc-web && \
@@ -58,5 +59,5 @@ source ./scripts/test-proxy.sh
 docker-compose down
 
 # Run unit tests from npm package
-docker run --rm grpcweb/common /bin/bash \
+docker run --rm grpcweb/prereqs /bin/bash \
   /github/grpc-web/scripts/docker-run-tests.sh


### PR DESCRIPTION
Fixes #269 

 - Now that we have pre-built binaries for the `protoc-gen-grpc-web` plugin, we can simplify the Quick Start docker images size by a lot. Now the `docker-compose pull` images go down from almost 5Gb to <1Gb. 
 - Update most README to indicate that user no longer needs to compile the `protoc-gen-grpc-web` plugin. Instead, user should be able to download the pre-built binaries from our Github release page
 - Separate the base `docker-compose.yml` with a different `advanced.yml` to not to confuse users. The rest of the docker images in `advanced.yml` were mostly used to run tests triggered by PR.