### PR TITLE
Emit status event on empty stream response

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -124,7 +124,7 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
     if (grpcStatusCode && self.onStatusCallback_) {
       self.onStatusCallback_({
         code: Number(grpcStatusCode),
-        details: grpcStatusMessage,
+        details: grpcStatusMessage || '',
         metadata: undefined,
       });
     }

--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -119,6 +119,16 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
     if (!contentType) return;
     contentType = contentType.toLowerCase();
 
+    var grpcStatusCode = self.xhr_.getStreamingResponseHeader(GRPC_STATUS);
+    var grpcStatusMessage = self.xhr_.getStreamingResponseHeader(GRPC_STATUS_MESSAGE);
+    if (grpcStatusCode && self.onStatusCallback_) {
+      self.onStatusCallback_({
+        code: Number(grpcStatusCode),
+        details: grpcStatusMessage,
+        metadata: undefined,
+      });
+    }
+
     if (googString.startsWith(contentType, 'application/grpc-web-text')) {
       var responseText = self.xhr_.getResponseText();
       var newPos = responseText.length - responseText.length % 4;
@@ -155,8 +165,8 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
               messages[i][FrameType.TRAILER][pos]);
           }
           var trailers = self.parseHttp1Headers_(trailerString);
-          var grpcStatusCode = StatusCode.OK;
-          var grpcStatusMessage = "";
+          grpcStatusCode = StatusCode.OK;
+          grpcStatusMessage = "";
           if (GRPC_STATUS in trailers) {
             grpcStatusCode = trailers[GRPC_STATUS];
           }


### PR DESCRIPTION
When stream is closed immediately by the server grpc-status and grpc-message headers are populated. 
Current implementation is broken as it does not fire `status` or `end` event in that case.