### PR TITLE
fix whitespace in build script

### DIFF
--- a/packages/grpc-web/scripts/build.js
+++ b/packages/grpc-web/scripts/build.js
@@ -46,7 +46,7 @@ const closureArgs = [].concat(
   [
     `--dependency_mode=STRICT`,
     `--js_output_file=${indexPath}`,
-    `--output_wrapper="%output%module.exports = grpc.web;"`,
+    `--output_wrapper="%output%module.exports=grpc.web;"`,
   ]
 );
 


### PR DESCRIPTION
Node's exec implementation is splitting on whitespace, causing the last argument to be improperly passed:

```
google-closure-compiler --js=../../javascript --js=../../third_party/closure-library --js=../../third_party/grpc/third_party/protobuf/js --entry_point=grpc.web.AbstractClientBase --entry_point=grpc.web.ClientReadableStream --entry_point=grpc.web.Error --entry_point=grpc.web.GrpcWebClientBase --entry_point=grpc.web.GrpcWebClientReadableStream --entry_point=grpc.web.GrpcWebStreamParser --entry_point=grpc.web.Status --entry_point=grpc.web.StatusCode --dependency_mode=STRICT --js_output_file=index.js --output_wrapper="%output%module.exports = grpc.web;"                                    
ERROR - Cannot read file =: =                                    

ERROR - Cannot read file grpc.web;: grpc.web;                    

2 error(s), 0 warning(s)
```

Removing the whitespace in the last argument fixes the issue and also makes the final payload 2 bytes smaller ;)