### PR TITLE
Promise function should use ES5 functions rather than fat arrows (IE browser support)

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -875,9 +875,10 @@ void PrintPromiseUnaryCall(Printer* printer,
   printer->Indent();
   printer->Print(vars,
                  "  function(request, metadata) {\n"
-                 "return new Promise((resolve, reject) => {\n"
-                 "  this.delegateClient_.$js_method_name$(\n"
-                 "    request, metadata, (error, response) => {\n"
+                 "var _this = this;\n"
+                 "return new Promise(function (resolve, reject) {\n"
+                 "  _this.delegateClient_.$js_method_name$(\n"
+                 "    request, metadata, function (error, response) {\n"
                  "      error ? reject(error) : resolve(response);\n"
                  "    });\n"
                  "});\n");


### PR DESCRIPTION
Arrow functions are not compatible with IE11, this fix allows the generated JS to be used directly in the browser without going through a seperate transpiler (Babel)