### PR TITLE
feature: Messages in typings extending jspb.Message

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -677,7 +677,7 @@ void PrintProtoDtsMessage(Printer *printer, const Descriptor *desc, const FileDe
   std::map<string, string> vars;
   vars["class_name"] = class_name;
 
-  printer->Print(vars, "export class $class_name$ {\n");
+  printer->Print(vars, "export class $class_name$ extends jspb.Message {\n");
   printer->Indent();
   printer->Print("constructor ();\n");
   for (int i = 0; i < desc->field_count(); i++)
@@ -688,9 +688,12 @@ void PrintProtoDtsMessage(Printer *printer, const Descriptor *desc, const FileDe
     printer->Print(vars, "set$js_field_name$(a: $js_field_type$): void;\n");
   }
   printer->Print(vars,
-                "toObject(): $class_name$.AsObject;\n"
                 "serializeBinary(): Uint8Array;\n"
-                "static deserializeBinary: (bytes: {}) => $class_name$;\n");
+                "toObject(includeInstance?: boolean): $class_name$.AsObject;\n"
+                "static toObject(includeInstance: boolean, msg: $class_name$): $class_name$.AsObject;\n"
+                "static serializeBinaryToWriter(message: $class_name$, writer: jspb.BinaryWriter): void;\n"
+                "static deserializeBinary(bytes: Uint8Array): $class_name$;\n"
+                "static deserializeBiinaryFromReader(message: $class_name$, reader: jspb.BinaryReader): $class_name$;\n");
   printer->Outdent();
   printer->Print("}\n\n");
 
@@ -723,6 +726,7 @@ void PrintProtoDtsMessage(Printer *printer, const Descriptor *desc, const FileDe
 
 void PrintProtoDtsFile(Printer *printer, const FileDescriptor *file)
 {
+  printer->Print("import * as jspb from \"google-protobuf\"\n\n");
   PrintES6Dependencies(printer, file);
 
   for (int i = 0; i < file->message_type_count(); i++) {

--- a/net/grpc/gateway/examples/echo/ts-example/package.json
+++ b/net/grpc/gateway/examples/echo/ts-example/package.json
@@ -1,12 +1,13 @@
 {
   "dependencies": {
-    "@types/node": "^10.7.1",
+    "@types/google-protobuf": "^3.2.7",
     "@types/jquery": "^3.3.6",
+    "@types/node": "^10.7.1",
     "browserify": "^16.2.2",
-    "jquery": "^3.3.1",
-    "mock-xmlhttprequest": "^2.0.0",
     "google-protobuf": "^3.6.1",
     "grpc-web": "^1.0.0",
+    "jquery": "^3.3.1",
+    "mock-xmlhttprequest": "^2.0.0",
     "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0"
   }


### PR DESCRIPTION
In generated protobuf typings extend jspb.Message to expose methods, add missing parameters and static methods.

Example:
https://github.com/shaxbee/grpc-web-dts-example/blob/master/typings-extend-jspb-message/example/example_pb.d.ts

Resolves #442 