### PR TITLE
fix: exclude map entry message from typings, fix optional values

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -59,6 +59,76 @@ enum ImportStyle {
   TYPESCRIPT = 2,  // import * as grpcWeb from 'grpc-web'
 };
 
+const char* kKeyword[] = {
+  "abstract",
+  "boolean",
+  "break",
+  "byte",
+  "case",
+  "catch",
+  "char",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "double",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "final",
+  "finally",
+  "float",
+  "for",
+  "function",
+  "goto",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "int",
+  "interface",
+  "long",
+  "native",
+  "new",
+  "null",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "short",
+  "static",
+  "super",
+  "switch",
+  "synchronized",
+  "this",
+  "throw",
+  "throws",
+  "transient",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "volatile",
+  "while",
+  "with",
+};
+
+bool IsReserved(const string& ident) {
+  for (int i = 0; i < sizeof(kKeyword) / sizeof(kKeyword[0]); i++) {
+    if (ident == kKeyword[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
 string GetModeVar(const Mode mode) {
   switch (mode) {
     case OP:
@@ -784,7 +854,11 @@ void PrintProtoDtsMessage(Printer *printer, const Descriptor *desc,
   printer->Indent();
   for (int i = 0; i < desc->field_count(); i++) {
     const FieldDescriptor* field = desc->field(i);
-    vars["js_field_name"] = CamelCaseJSFieldName(field);
+    string js_field_name = CamelCaseJSFieldName(field);
+    if (IsReserved(js_field_name)) {
+      js_field_name = "pb_" + js_field_name;
+    }
+    vars["js_field_name"] = js_field_name;
     vars["js_field_type"] = AsObjectFieldType(field, file);
     if (field->type() != FieldDescriptor::TYPE_MESSAGE || field->is_repeated()) {
       printer->Print(vars, "$js_field_name$: $js_field_type$,\n");

--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -21,6 +21,7 @@
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/io/zero_copy_stream.h>
+#include <google/protobuf/descriptor.pb.h>
 #include <algorithm>
 #include <string>
 
@@ -274,9 +275,28 @@ string JSFieldType(const FieldDescriptor *desc, const FileDescriptor *file)
   }
   if (desc->is_repeated())
   {
-    js_field_type += "[]";
+    js_field_type = "Array<" + js_field_type + ">";
   }
   return js_field_type;
+}
+
+string AsObjectFieldType(const FieldDescriptor *desc, const FileDescriptor *file) {
+  if (desc->type() != FieldDescriptor::TYPE_MESSAGE) {
+    return JSFieldType(desc, file);
+  };
+
+  if (desc->is_map()) {
+    const Descriptor* message = desc->message_type();
+    string key_type = AsObjectFieldType(message->field(0), file);
+    string value_type = AsObjectFieldType(message->field(1), file);
+    return "Array<[" + key_type + ", " + value_type + "]>";
+  };
+  
+  string field_type = JSMessageType(desc->message_type(), file) + ".AsObject";
+  if (desc->is_repeated()) {
+    field_type = "Array<" + field_type + ">";
+  }
+  return field_type;
 }
 
 string JSFieldName(const FieldDescriptor *desc)
@@ -698,24 +718,37 @@ void PrintProtoDtsMessage(Printer *printer, const Descriptor *desc,
     const FieldDescriptor* field = desc->field(i);
     vars["js_field_name"] = JSFieldName(field);
     vars["js_field_type"] = JSFieldType(field, file);
-    if (field->type() != FieldDescriptor::TYPE_MESSAGE) {
+    if (field->type() != FieldDescriptor::TYPE_MESSAGE || field->is_repeated()) {
       printer->Print(vars,
                      "get$js_field_name$(): $js_field_type$;\n");
     } else {
       printer->Print(vars,
                      "get$js_field_name$(): $js_field_type$ | undefined;\n");
     }
-    if (field->type() != FieldDescriptor::TYPE_MESSAGE) {
+    if (field->type() != FieldDescriptor::TYPE_MESSAGE || field->is_repeated()) {
       printer->Print(vars,
                      "set$js_field_name$(value: $js_field_type$): void;\n");
     } else if (!field->is_map()) {
       printer->Print(vars,
                      "set$js_field_name$(value?: $js_field_type$): void;\n");
     }
+    if (field->is_repeated() && !field->is_map()) {
+      printer->Print(vars, "clear$js_field_name$(): void;\n");
+      vars["js_field_name"] = JSElementName(field);
+      vars["js_field_type"] = JSElementType(field, file);
+      if (field->type() != FieldDescriptor::TYPE_MESSAGE) {
+        printer->Print(vars, 
+                       "add$js_field_name$(value: $js_field_type$, index?: number);\n");
+      } else {
+        printer->Print(vars, 
+                       "add$js_field_name$(value?: $js_field_type$, index?: number): $js_field_type$;\n");
+      }
+    }
     if (field->type() == FieldDescriptor::TYPE_MESSAGE ||
         field->is_repeated()) {
       printer->Print(vars, "clear$js_field_name$(): void;\n");
     }
+    printer->Print("\n");
   }
   printer->Print(
       vars,
@@ -739,16 +772,10 @@ void PrintProtoDtsMessage(Printer *printer, const Descriptor *desc,
   for (int i = 0; i < desc->field_count(); i++) {
     const FieldDescriptor* field = desc->field(i);
     vars["js_field_name"] = CamelCaseJSFieldName(field);
-    if (field->type() != FieldDescriptor::TYPE_MESSAGE) {
-      vars["js_field_type"] = JSFieldType(field, file);
-      printer->Print(vars, "$js_field_name$: $js_field_type$;\n");
+    vars["js_field_type"] = AsObjectFieldType(field, file);
+    if (field->type() != FieldDescriptor::TYPE_MESSAGE || field->is_repeated()) {
+      printer->Print(vars, "$js_field_name$: $js_field_type$,\n");
     } else {
-      string js_field_type = JSMessageType(field->message_type(), file) +
-                             ".AsObject";
-      if (field->is_repeated()) {
-        js_field_type += "[]";
-      }
-      vars["js_field_type"] = js_field_type;
       printer->Print(vars, "$js_field_name$?: $js_field_type$;\n");
     }
   }
@@ -756,6 +783,9 @@ void PrintProtoDtsMessage(Printer *printer, const Descriptor *desc,
   printer->Print("}\n");
 
   for (int i = 0; i < desc->nested_type_count(); i++) {
+    if (desc->options().map_entry()) {
+      continue;
+    }
     printer->Print("\n");
     PrintProtoDtsMessage(printer, desc->nested_type(i), file);
   }


### PR DESCRIPTION
This PR brings bindings in line with `ts-protoc-gen`.

Do not generate typings for proto `map` entry type.
Fix optionality of `repeated` fields - array fields are required.
Add `has$field_name$` method for message fields.
Add `add$element_name$` method for repeated fields.
Support `[jstype=JS_STRING]` field option.
Prefix reserved fields in AsObject with `pb_` prefix.

Example:
https://github.com/shaxbee/grpc-web-dts-example/blob/master/map-asobject/example/example_pb.d.ts