### PR TITLE
Partial revert of #422

### DIFF
--- a/javascript/net/grpc/web/error.js
+++ b/javascript/net/grpc/web/error.js
@@ -28,13 +28,12 @@ goog.module.declareLegacyNamespace();
 
 
 
-/** @record */
-function Error() {}
-
-/** @export {(number|undefined)} */
-Error.prototype.code;
-
-/** @export {(string|undefined)} */
-Error.prototype.message;
+/**
+ * @typedef {{
+ *   code: (number|undefined),
+ *   message: (string|undefined),
+ * }}
+ */
+let Error;
 
 exports = Error;

--- a/javascript/net/grpc/web/status.js
+++ b/javascript/net/grpc/web/status.js
@@ -28,16 +28,11 @@ goog.module.declareLegacyNamespace();
 
 
 
-/** @record */
-function Status() {}
-
-/** @export {number} */
-Status.prototype.code;
-
-/** @export {string} */
-Status.prototype.details;
-
-/** @export {(!Object<string, string>|undefined)} */
-Status.prototype.metadata;
-
-exports.Status = Status;
+/**
+ * @typedef {{
+ *   code: number,
+ *   details: string,
+ *   metadata: (!Object<string, string>|undefined)
+ * }}
+ */
+exports.Status;

--- a/packages/grpc-web/scripts/build.js
+++ b/packages/grpc-web/scripts/build.js
@@ -35,7 +35,6 @@ const closureArgs = [].concat(
     `--entry_point=grpc.web.Exports`,
     `--externs=externs.js`,
     `--dependency_mode=STRICT`,
-    `--compilation_level=ADVANCED_OPTIMIZATIONS`,
     `--generate_exports`,
     `--export_local_property_definitions`,
     `--js_output_file=${indexPath}`,


### PR DESCRIPTION
I have to partially revert #422 - some changes to `status.js` and `error.js` are breaking internal test cases. I think some internal test cases are depending on the fact that the `Error` and `Status` classes are `@typedef` instead of `@record` (although I am somewhat uncertain about some intricacy of Closure JSDoc). We should investigate this further. In the meantime, in order to make sure both codebases are in sync and tests passing, I am partially reverting these 2 changes.