### PR TITLE
feat: support for with-credentials xhr flag

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -647,7 +647,7 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
       printer->Print(vars, "options['format'] = '$format$';\n\n");
     }
     printer->Print(vars,
-                   "this.client_ = new grpcWeb.$mode$ClientBase(options);\n"
+                   "this.client_ = new grpcWeb.$mode$ClientBase(options, credentials);\n"
                    "this.hostname_ = hostname;\n"
                    "this.credentials_ = credentials;\n"
                    "this.options_ = options;\n");
@@ -1004,7 +1004,7 @@ void PrintServiceConstructor(Printer* printer,
       "  /**\n"
       "   * @private @const {!grpc.web.$mode$ClientBase} The client\n"
       "   */\n"
-      "  this.client_ = new grpc.web.$mode$ClientBase(options);\n\n"
+      "  this.client_ = new grpc.web.$mode$ClientBase(options, credentials);\n\n"
       "  /**\n"
       "   * @private @const {string} The hostname\n"
       "   */\n"
@@ -1043,7 +1043,7 @@ void PrintPromiseServiceConstructor(Printer* printer,
       "  /**\n"
       "   * @private @const {!grpc.web.$mode$ClientBase} The client\n"
       "   */\n"
-      "  this.client_ = new grpc.web.$mode$ClientBase(options);\n\n"
+      "  this.client_ = new grpc.web.$mode$ClientBase(options, credentials);\n\n"
       "  /**\n"
       "   * @private @const {string} The hostname\n"
       "   */\n"

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -39,10 +39,11 @@ const googCrypt = goog.require('goog.crypt.base64');
 /**
  * Base class for gRPC web client using the application/grpc-web wire format
  * @param {?Object=} opt_options
+ * @param {boolean=} credentials
  * @constructor
  * @implements {AbstractClientBase}
  */
-const GrpcWebClientBase = function(opt_options) {
+const GrpcWebClientBase = function(opt_options, credentials) {
   /**
    * @const
    * @private {string}
@@ -56,6 +57,13 @@ const GrpcWebClientBase = function(opt_options) {
    */
   this.suppressCorsPreflight_ =
     goog.getObjectByName('suppressCorsPreflight', opt_options) || false;
+
+
+  /**
+   * @const
+   * @private {boolean}
+   */
+  this.credentials_ = !!credentials;
 };
 
 
@@ -171,7 +179,9 @@ GrpcWebClientBase.prototype.serverStreaming = function(
  * @return {!XhrIo} The created XhrIo object
  */
 GrpcWebClientBase.prototype.newXhr_ = function() {
-  return new XhrIo();
+  var xhrIo = new XhrIo();
+  xhrIo.setWithCredentials(this.credentials_);
+  return xhrIo;
 };
 
 


### PR DESCRIPTION
Add support for xhr's with-credential flag ([specs](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials)).

A new optional parameter is added to clients constructors. If not set the default value is false, so it does not change the prior behavior.

Usage:
```
const WITH_CREDENTIALS = true;
const client = new SomeServiceClient('https://www.some-domain.com:8443', WITH_CREDENTIALS);
``` 

Related issues: #176, #351 