### PR TITLE
Make client args `credentials` and `options` optional

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -639,8 +639,8 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
         "credentials_: null | { [index: string]: string; };\n"
         "options_: null | { [index: string]: string; };\n\n"
         "constructor (hostname: string,\n"
-        "             credentials: null | { [index: string]: string; },\n"
-        "             options: null | { [index: string]: string; }) {\n");
+        "             credentials?: null | { [index: string]: string; },\n"
+        "             options?: null | { [index: string]: string; }) {\n");
     printer->Indent();
     printer->Print("if (!options) options = {};\n");
     if (vars["mode"] == GetModeVar(Mode::GRPCWEB)) {
@@ -734,8 +734,8 @@ void PrintGrpcWebDtsClientClass(Printer* printer, const FileDescriptor* file,
     printer->Indent();
     printer->Print(
         "constructor (hostname: string,\n"
-        "             credentials: null | { [index: string]: string; },\n"
-        "             options: null | { [index: string]: string; });\n\n");
+        "             credentials?: null | { [index: string]: string; },\n"
+        "             options?: null | { [index: string]: string; });\n\n");
     for (int method_index = 0; method_index < service->method_count();
          ++method_index) {
       const MethodDescriptor* method = service->method(method_index);


### PR DESCRIPTION
Currently the TypeScript generated clients require that `null` be passed to `credentials` and `options` if they're not being used.  It's easier to simply make those arguments optional.  I've left the `null` portion of the type though to maintain backwards compatibility.