### PR TITLE
remove duplicated has$field$ method for oneof

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -879,9 +879,6 @@ void PrintProtoDtsMessage(Printer *printer, const Descriptor *desc,
                        "index?: number): $js_field_type$;\n");
       }
     }
-    if (field->containing_oneof() != nullptr) {
-      printer->Print(vars, "has$js_field_name$(): boolean;\n");
-    }
 
     printer->Print("\n");
   }


### PR DESCRIPTION
Sorry. I didn't noticed that `has$field$` method has be defined during resolving conflicts in PR #460. 

Thanks to @rogchap for pointing out this issue.