### PR TITLE
Fix grpc-web package typescript type error

### DIFF
--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -6,7 +6,7 @@ declare module "grpc-web" {
     class MethodInfo<Request, Response> {
       constructor (responseType: new () => Response,
                    requestSerializeFn: (request: Request) => {},
-                   responseDeserializeFn: (bytes: {}) => Response);
+                   responseDeserializeFn: (bytes: any) => Response);
     }
   }
 


### PR DESCRIPTION
With grpc-web release 1.0.4, grpc-web package's index.d.ts casues
the following errors.

```
EchoServiceClientPb.ts:44:5 - error TS2345: Argument of type '(bytes: Uint8Array) => EchoResponse' is not assignable to parameter of type '(bytes: {}) => EchoResponse'.  Types of parameters 'bytes' and 'bytes' are incompatible.
    Type '{}' is missing the following properties from type
'Uint8Array': BYTES_PER_ELEMENT, buffer, byteLength, byteOffset, and 26
more.

44     EchoResponse.deserializeBinary
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This is because `UInt8Array => T` argument is given for `{} => T` parameter.
Closure compiler type of `responseDeserializeFn` is `? => RESPONSE`,
which corresponds to `any => T` in the parameter context, not `{}`.

This fix changes `{}` to `any` in order to solve the above problem.