### PR TITLE
Method Derserializer should take Uint8Array

### DIFF
--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -6,7 +6,7 @@ declare module "grpc-web" {
     class MethodInfo<Request, Response> {
       constructor (responseType: new () => Response,
                    requestSerializeFn: (request: Request) => {},
-                   responseDeserializeFn: (bytes: {}) => Response);
+                   responseDeserializeFn: (bytes: Uint8Array) => Response);
     }
   }
 


### PR DESCRIPTION
Currently running into issue:

```
Type '{}' is not assignable to type 'Uint8Array'.
```

This fixes it for me.