### PR TITLE
fix: Add command to update package lists

### DIFF
--- a/net/grpc/gateway/docker/closure_client/Dockerfile
+++ b/net/grpc/gateway/docker/closure_client/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM grpcweb/prereqs
 
-RUN apt-get -qq install -y \
+RUN apt-get -qq update && apt-get -qq install -y \
   default-jdk
 
 RUN cd /github/grpc-web && \


### PR DESCRIPTION
Add `apt-get -qq update` to quietly update the debian stretch package list
so the `apt-get -qq install -y default-jdk` does not fail due to 404s.