### PR TITLE
Fix TypeScript type issue

### DIFF
--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -6,7 +6,7 @@ declare module "grpc-web" {
     class MethodInfo<Request, Response> {
       constructor (responseType: new () => Response,
                    requestSerializeFn: (request: Request) => {},
-                   responseDeserializeFn: (bytes: {}) => Response);
+                   responseDeserializeFn: (bytes: Uint8Array) => Response);
     }
   }
 


### PR DESCRIPTION
The generated code from 1.0.4 currently doesn't typecheck because this type is wrong.