### PR TITLE
Add fix for deadline of strings, NaN, Infinity and -Infinity

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -221,8 +221,7 @@ GrpcWebClientBase.prototype.processHeaders_ = function(xhr) {
       var maxSafeInteger = Math.pow(2, 53) - 1;
       timeout = maxSafeInteger;
     }
-    // isFinite discards NaN and -Infinity
-    if (isFinite(timeout) && timeout > 0) {
+    if (timeout > 0) {
       xhr.headers.set('grpc-timeout', timeout + 'm');
     }
   }

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -217,8 +217,7 @@ GrpcWebClientBase.prototype.processHeaders_ = function(xhr) {
     var timeout = Math.round(deadline - currentTime);
     xhr.headers.remove('deadline');
     if (timeout === Infinity) {
-      // Polyfill for "Number.MAX_SAFE_INTEGER"
-      var maxSafeInteger = Math.pow(2, 53) - 1;
+      var maxSafeInteger = 2147483647; // 2^31 - 1
       timeout = maxSafeInteger;
     }
     if (timeout > 0) {

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -216,10 +216,16 @@ GrpcWebClientBase.prototype.processHeaders_ = function(xhr) {
     var currentTime = (new Date()).getTime();
     var timeout = Math.round(deadline - currentTime);
     xhr.headers.remove('deadline');
-    if (timeout > 0) {
+    if (timeout === Infinity) {
+      // Polyfill for "Number.MAX_SAFE_INTEGER"
+      var maxSafeInteger = Math.pow(2, 53) - 1;
+      timeout = maxSafeInteger;
+    }
+    // isFinite discards NaN and -Infinity
+    if (isFinite(timeout) && timeout > 0) {
       xhr.headers.set('grpc-timeout', timeout + 'm');
     }
-  }    
+  }
 };
 
 /**

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -217,8 +217,8 @@ GrpcWebClientBase.prototype.processHeaders_ = function(xhr) {
     var timeout = Math.round(deadline - currentTime);
     xhr.headers.remove('deadline');
     if (timeout === Infinity) {
-      var maxSafeInteger = 2147483647; // 2^31 - 1
-      timeout = maxSafeInteger;
+      // grpc-timeout header defaults to infinity if not set.
+      timeout = 0;
     }
     if (timeout > 0) {
       xhr.headers.set('grpc-timeout', timeout + 'm');


### PR DESCRIPTION
This will change `Infinity` to `Math.pow(2, 53) - 1` (`Number.MAX_SAFE_INTEGER` in ES6, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). Anything that becomes `NaN` will be discarded (for example setting deadline to a string or `NaN`), `-Infinity` will also be discarded.

I don't know if it is best to let bad values for deadlines slip past silently or not...