### PR TITLE
Introducing MethodDescriptor

### DIFF
--- a/javascript/net/grpc/web/BUILD.bazel
+++ b/javascript/net/grpc/web/BUILD.bazel
@@ -22,6 +22,7 @@ closure_js_library(
     deps = [
         ":clientreadablestream",
         ":error",
+        ":methoddescriptor",
     ],
 )
 
@@ -104,6 +105,13 @@ closure_js_library(
     deps = [
         "@io_bazel_rules_closure//closure/library/asserts",
         "@io_bazel_rules_closure//closure/library/net/streams:streamparser",
+    ],
+)
+
+closure_js_library(
+    name = "methoddescriptor",
+    srcs = [
+        "methoddescriptor.js",
     ],
 )
 

--- a/javascript/net/grpc/web/BUILD.bazel
+++ b/javascript/net/grpc/web/BUILD.bazel
@@ -113,6 +113,16 @@ closure_js_library(
     srcs = [
         "methoddescriptor.js",
     ],
+    deps = [
+        ":methodtype",
+    ],
+)
+
+closure_js_library(
+    name = "methodtype",
+    srcs = [
+        "methodtype.js",
+    ],
 )
 
 closure_js_library(

--- a/javascript/net/grpc/web/abstractclientbase.js
+++ b/javascript/net/grpc/web/abstractclientbase.js
@@ -121,4 +121,3 @@ AbstractClientBase.prototype.serverStreaming = goog.abstractMethod;
 
 
 exports = AbstractClientBase;
-

--- a/javascript/net/grpc/web/abstractclientbase.js
+++ b/javascript/net/grpc/web/abstractclientbase.js
@@ -29,6 +29,7 @@ goog.module.declareLegacyNamespace();
 
 const ClientReadableStream = goog.require('grpc.web.ClientReadableStream');
 const Error = goog.require('grpc.web.Error');
+const MethodDescriptor = goog.require('grpc.web.MethodDescriptor');
 
 
 /**
@@ -80,7 +81,8 @@ AbstractClientBase.MethodInfo = function(
  * @param {string} method The method to invoke
  * @param {REQUEST} request The request proto
  * @param {!Object<string, string>} metadata User defined call metadata
- * @param {!AbstractClientBase.MethodInfo<REQUEST, RESPONSE_LEAN>}
+ * @param {!AbstractClientBase.MethodInfo<REQUEST,
+ *     RESPONSE_LEAN>|!MethodDescriptor<REQUEST, RESPONSE_LEAN>}
  *   methodInfo Information of this RPC method
  * @param {function(?Error, ?RESPONSE)}
  *   callback A callback function which takes (error, response)
@@ -95,7 +97,8 @@ AbstractClientBase.prototype.rpcCall = goog.abstractMethod;
  * @param {string} method The method to invoke
  * @param {REQUEST} request The request proto
  * @param {!Object<string, string>} metadata User defined call metadata
- * @param {!AbstractClientBase.MethodInfo<REQUEST, RESPONSE>}
+ * @param {!AbstractClientBase.MethodInfo<REQUEST,
+ *     RESPONSE>|!MethodDescriptor<REQUEST, RESPONSE>}
  *   methodInfo Information of this RPC method
  * @return {!Promise<!RESPONSE>}
  *   A promise that resolves to the response message
@@ -108,7 +111,8 @@ AbstractClientBase.prototype.unaryCall = goog.abstractMethod;
  * @param {string} method The method to invoke
  * @param {REQUEST} request The request proto
  * @param {!Object<string, string>} metadata User defined call metadata
- * @param {!AbstractClientBase.MethodInfo<REQUEST, RESPONSE>}
+ * @param {!AbstractClientBase.MethodInfo<REQUEST,
+ *     RESPONSE>|!MethodDescriptor<REQUEST, RESPONSE>}
  *   methodInfo Information of this RPC method
  * @return {!ClientReadableStream<RESPONSE>} The Client Readable Stream
  */

--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -1075,7 +1075,7 @@ void PrintMethodInfo(Printer* printer, std::map<string, string> vars) {
   printer->Print(vars,
                  "'/$package_dot$$service_name$/$method_name$',\n"
                  "$method_type$,\n"
-                 "proto.$in$,\n");
+                 "$in_type$,\n");
   printer->Print(vars,
                  "$out_type$,\n"
                  "/** @param {!proto.$in$} request */\n"
@@ -1350,6 +1350,7 @@ class GrpcCodeGenerator : public CodeGenerator {
         printer.Print(vars, "goog.require('grpc.web.ClientReadableStream');\n");
         printer.Print(vars, "goog.require('grpc.web.Error');\n");
         printer.Print(vars, "goog.require('grpc.web.MethodDescriptor');\n");
+        printer.Print(vars, "goog.require('grpc.web.MethodType');\n");
 
         PrintMessagesDeps(&printer, file);
         printer.Print("goog.scope(function() {\n\n");
@@ -1385,22 +1386,24 @@ class GrpcCodeGenerator : public CodeGenerator {
           // of the global name.
           vars["out_type"] = ModuleAlias(method->output_type()->file()->name())
                              + GetNestedMessageName(method->output_type());
+          vars["in_type"] = ModuleAlias(method->input_type()->file()->name()) +
+                            GetNestedMessageName(method->input_type());
         } else {
-          vars["out_type"] = "proto."+method->output_type()->full_name();
+          vars["out_type"] = "proto." + method->output_type()->full_name();
+          vars["in_type"] = "proto." + method->input_type()->full_name();
         }
 
         // Client streaming is not supported yet
         if (!method->client_streaming()) {
           if (method->server_streaming()) {
-            vars["method_type"] =
-                "grpc.web.MethodDescriptor.MethodType.SERVER_STREAMING";
+            vars["method_type"] = "grpc.web.MethodType.SERVER_STREAMING";
             PrintMethodInfo(&printer, vars);
             vars["client_type"] = "Client";
             PrintServerStreamingCall(&printer, vars);
             vars["client_type"] = "PromiseClient";
             PrintServerStreamingCall(&printer, vars);
           } else {
-            vars["method_type"] = "grpc.web.MethodDescriptor.MethodType.UNARY";
+            vars["method_type"] = "grpc.web.MethodType.UNARY";
             PrintMethodInfo(&printer, vars);
             PrintUnaryCall(&printer, vars);
             PrintPromiseUnaryCall(&printer, vars);

--- a/javascript/net/grpc/web/methoddescriptor.js
+++ b/javascript/net/grpc/web/methoddescriptor.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Description of this file.
+ *
+ * A templated class that is used to address gRPC Web requests.
+ */
+
+goog.module('grpc.web.MethodDescriptor');
+goog.module.declareLegacyNamespace();
+
+/**
+ * @constructor
+ * @struct
+ * @template REQUEST, RESPONSE
+ * @param {string} name
+ * @param {!MethodDescriptor.MethodType} methodType
+ * @param {function(new: REQUEST, ...)} requestType
+ * @param {function(new: RESPONSE, ...)} responseType
+ * @param {function(REQUEST): ?} requestSerializeFn
+ * @param {function(?): RESPONSE} responseDeserializeFn
+ */
+const MethodDescriptor = function(
+    name, methodType, requestType, responseType, requestSerializeFn,
+    responseDeserializeFn) {
+  /** @const */
+  this.name = name;
+  /** @const */
+  this.methodType = methodType;
+  /** @const */
+  this.requestType = requestType;
+  /** @const */
+  this.responseType = responseType;
+  /** @const */
+  this.requestSerializeFn = requestSerializeFn;
+  /** @const */
+  this.responseDeserializeFn = responseDeserializeFn;
+};
+
+/**
+ * @enum {string}
+ */
+MethodDescriptor.MethodType = {
+  'UNARY': 'unary',
+  'SERVER_STREAMING': 'server_streaming'
+};
+
+exports = MethodDescriptor;

--- a/javascript/net/grpc/web/methoddescriptor.js
+++ b/javascript/net/grpc/web/methoddescriptor.js
@@ -7,12 +7,14 @@
 goog.module('grpc.web.MethodDescriptor');
 goog.module.declareLegacyNamespace();
 
+const MethodType = goog.require('grpc.web.MethodType');
+
 /**
  * @constructor
  * @struct
  * @template REQUEST, RESPONSE
  * @param {string} name
- * @param {!MethodDescriptor.MethodType} methodType
+ * @param {!MethodType} methodType
  * @param {function(new: REQUEST, ...)} requestType
  * @param {function(new: RESPONSE, ...)} responseType
  * @param {function(REQUEST): ?} requestSerializeFn
@@ -33,14 +35,6 @@ const MethodDescriptor = function(
   this.requestSerializeFn = requestSerializeFn;
   /** @const */
   this.responseDeserializeFn = responseDeserializeFn;
-};
-
-/**
- * @enum {string}
- */
-MethodDescriptor.MethodType = {
-  'UNARY': 'unary',
-  'SERVER_STREAMING': 'server_streaming'
 };
 
 exports = MethodDescriptor;

--- a/javascript/net/grpc/web/methodtype.js
+++ b/javascript/net/grpc/web/methodtype.js
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Description of this file.
+ *
+ * grpc web MethodType
+ */
+
+goog.module('grpc.web.MethodType');
+
+goog.module.declareLegacyNamespace();
+
+/**
+ * See grpc.web.AbstractClientBase.
+ * MethodType.UNARY for rpcCall/unaryCall.
+ * MethodType.SERVER_STREAMING for serverStreaming.
+ *
+ * @enum {string}
+ */
+const MethodType = {
+  'UNARY': 'unary',
+  'SERVER_STREAMING': 'server_streaming'
+};
+
+exports = MethodType;

--- a/packages/grpc-web/exports.js
+++ b/packages/grpc-web/exports.js
@@ -9,9 +9,11 @@ goog.module('grpc.web.Exports');
 const AbstractClientBase = goog.require('grpc.web.AbstractClientBase');
 const GrpcWebClientBase = goog.require('grpc.web.GrpcWebClientBase');
 const StatusCode = goog.require('grpc.web.StatusCode');
+const MethodDescriptor = goog.require('grpc.web.MethodDescriptor');
 
 const exports = module['exports'];
 
 exports['AbstractClientBase'] = {'MethodInfo': AbstractClientBase.MethodInfo};
 exports['GrpcWebClientBase'] = GrpcWebClientBase;
 exports['StatusCode'] = StatusCode;
+exports['MethodDescriptor'] = MethodDescriptor;

--- a/packages/grpc-web/exports.js
+++ b/packages/grpc-web/exports.js
@@ -10,6 +10,7 @@ const AbstractClientBase = goog.require('grpc.web.AbstractClientBase');
 const GrpcWebClientBase = goog.require('grpc.web.GrpcWebClientBase');
 const StatusCode = goog.require('grpc.web.StatusCode');
 const MethodDescriptor = goog.require('grpc.web.MethodDescriptor');
+const MethodType = goog.require('grpc.web.MethodType');
 
 const exports = module['exports'];
 
@@ -17,3 +18,4 @@ exports['AbstractClientBase'] = {'MethodInfo': AbstractClientBase.MethodInfo};
 exports['GrpcWebClientBase'] = GrpcWebClientBase;
 exports['StatusCode'] = StatusCode;
 exports['MethodDescriptor'] = MethodDescriptor;
+exports['MethodType'] = MethodType;

--- a/packages/grpc-web/test/export_test.js
+++ b/packages/grpc-web/test/export_test.js
@@ -7,6 +7,10 @@ describe('grpc-web export test', function() {
     assert.equal(typeof grpc.web.AbstractClientBase.MethodInfo, 'function');
   });
 
+  it('should have MethodDescriptor exported', function() {
+    assert.equal(typeof grpc.web.MethodDescriptor, 'function');
+  });
+
   it('should have GrpcWebClientBase#rpcCall() exported', function() {
     assert.equal(typeof grpc.web.GrpcWebClientBase.prototype.rpcCall, 'function');
   });


### PR DESCRIPTION
Related to #558. We are experimenting with introducing the `MethodDescriptor` class to eventually replace `AbstractClientBase.MethodInfo`. This will match the Client Interceptor proposal and will eventually be more flexible and expressive than the current MethodInfo definition. 

Creating this to start running some tests