### PR TITLE
Add `COPY` operation in client Dockerfile for local test

### DIFF
--- a/net/grpc/gateway/docker/commonjs_client/Dockerfile
+++ b/net/grpc/gateway/docker/commonjs_client/Dockerfile
@@ -16,6 +16,8 @@ FROM grpcweb/common
 
 ARG EXAMPLE_DIR=/github/grpc-web/net/grpc/gateway/examples/echo
 
+COPY net/grpc/gateway/examples/echo/commonjs-example/ $EXAMPLE_DIR/commonjs-example/
+
 RUN protoc -I=$EXAMPLE_DIR echo.proto \
 --js_out=import_style=commonjs:\
 $EXAMPLE_DIR/commonjs-example \

--- a/net/grpc/gateway/docker/ts_client/Dockerfile
+++ b/net/grpc/gateway/docker/ts_client/Dockerfile
@@ -16,6 +16,8 @@ FROM grpcweb/prereqs
 
 ARG EXAMPLE_DIR=/github/grpc-web/net/grpc/gateway/examples/echo
 
+COPY net/grpc/gateway/examples/echo/ts-example/ $EXAMPLE_DIR/ts-example/
+
 RUN npm install -g tsc typescript
 
 RUN protoc -I=$EXAMPLE_DIR echo.proto \


### PR DESCRIPTION
Add `COPY files` from host into container in `commonjs_client/Dockerfile` and `ts_client/Dockerfile`.
Make local test easier.