### PR TITLE
Fix depset issues with/upgrade to Bazel 0.27.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,10 +4,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "1f8d2e169bb292ef2adbe563bd66d5b8d4b462b6b869a67647e771ecef4b5030",
-    strip_prefix = "rules_closure-a176ec89a1b251bb5442ba569d47cee3c053e633",
+    sha256 = "fecda06179906857ac79af6500124bf03fe1630fd1b3d4dcf6c65346b9c0725d",
+    strip_prefix = "rules_closure-03110588392d8c6c05b99c08a6f1c2121604ca27",
     urls = [
-        "https://github.com/bazelbuild/rules_closure/archive/a176ec89a1b251bb5442ba569d47cee3c053e633.zip",
+        "https://github.com/bazelbuild/rules_closure/archive/03110588392d8c6c05b99c08a6f1c2121604ca27.zip",
     ],
 )
 

--- a/bazel/closure_grpc_web_library.bzl
+++ b/bazel/closure_grpc_web_library.bzl
@@ -41,7 +41,7 @@ def _proto_include_path(proto):
     return path
 
 def _proto_include_paths(protos):
-    return depset([_proto_include_path(proto) for proto in protos])
+    return [_proto_include_path(proto) for proto in protos]
 
 def _generate_closure_grpc_web_src_progress_message(name):
     # TODO(yannic): Add a better message?
@@ -60,7 +60,7 @@ def _generate_closure_grpc_web_srcs(
         "-I%s" % p
         for p in _proto_include_paths(
             [f for f in all_sources],
-        ).to_list()
+        )
     ]
 
     grpc_web_out_common_options = ",".join([

--- a/bazel/closure_grpc_web_library.bzl
+++ b/bazel/closure_grpc_web_library.bzl
@@ -55,12 +55,12 @@ def _generate_closure_grpc_web_srcs(
         mode,
         sources,
         transitive_sources):
-    all_sources = [src for src in sources] + [src for src in transitive_sources]
+    all_sources = [src for src in sources] + [src for src in transitive_sources.to_list()]
     proto_include_paths = [
         "-I%s" % p
         for p in _proto_include_paths(
             [f for f in all_sources],
-        )
+        ).to_list()
     ]
 
     grpc_web_out_common_options = ",".join([

--- a/scripts/kokoro.sh
+++ b/scripts/kokoro.sh
@@ -45,7 +45,7 @@ done
 docker-compose -f advanced.yml build
 
 # Run all bazel unit tests
-BAZEL_VERSION=0.27.0
+BAZEL_VERSION=0.27.1
 wget https://github.com/bazelbuild/bazel/releases/download/"${BAZEL_VERSION}"/bazel-"${BAZEL_VERSION}"-installer-linux-x86_64.sh
 chmod +x ./bazel-"${BAZEL_VERSION}"-installer-linux-x86_64.sh
 ./bazel-"${BAZEL_VERSION}"-installer-linux-x86_64.sh --user

--- a/scripts/kokoro.sh
+++ b/scripts/kokoro.sh
@@ -45,7 +45,7 @@ done
 docker-compose -f advanced.yml build
 
 # Run all bazel unit tests
-BAZEL_VERSION=0.23.1
+BAZEL_VERSION=0.27.0
 wget https://github.com/bazelbuild/bazel/releases/download/"${BAZEL_VERSION}"/bazel-"${BAZEL_VERSION}"-installer-linux-x86_64.sh
 chmod +x ./bazel-"${BAZEL_VERSION}"-installer-linux-x86_64.sh
 ./bazel-"${BAZEL_VERSION}"-installer-linux-x86_64.sh --user


### PR DESCRIPTION
This PR updates rules_closures and Bazel.

`depset` is no longer iterable starting from Bazel 0.27.0.