### PR TITLE
Fix: Helloworld Example - Enabled Deprecation

### DIFF
--- a/net/grpc/gateway/examples/helloworld/envoy.yaml
+++ b/net/grpc/gateway/examples/helloworld/envoy.yaml
@@ -31,7 +31,6 @@ static_resources:
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
                 expose_headers: custom-header-1,grpc-status,grpc-message
-                enabled: true
           http_filters:
           - name: envoy.grpc_web
           - name: envoy.cors


### PR DESCRIPTION
Fixes Envoy not starting up due to https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated
```
[2019-07-18 01:48:05.301][7][critical][main] [source/server/server.cc:93] error initializing configuration '/etc/envoy/envoy.yaml': Proto constraint validation failed (Using deprecated option 'envoy.api.v2.route.CorsPolicy.enabled' from file route.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.): allow_origin: "*"
allow_methods: "GET, PUT, DELETE, POST, OPTIONS"
allow_headers: "keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout"
expose_headers: "custom-header-1,grpc-status,grpc-message"
max_age: "1728000"
enabled {
  value: true
}

[2019-07-18 01:48:05.301][7][info][main] [source/server/server.cc:560] exiting
Proto constraint validation failed (Using deprecated option 'envoy.api.v2.route.CorsPolicy.enabled' from file route.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.): allow_origin: "*"
allow_methods: "GET, PUT, DELETE, POST, OPTIONS"
allow_headers: "keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout"
expose_headers: "custom-header-1,grpc-status,grpc-message"
max_age: "1728000"
enabled {
  value: true
}
```