### PR TITLE
Updating for new Envoy versions

### DIFF
--- a/net/grpc/gateway/examples/echo/envoy.yaml
+++ b/net/grpc/gateway/examples/echo/envoy.yaml
@@ -31,7 +31,6 @@ static_resources:
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
                 expose_headers: custom-header-1,grpc-status,grpc-message
-                enabled: true
           http_filters:
           - name: envoy.grpc_web
           - name: envoy.cors


### PR DESCRIPTION
Since 1.10.0 `enabled` is deprecated. Removing it works because the default is for filter to be enabled.

More information:
 * https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated
 * https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#envoy-api-field-route-corspolicy-enabled
 * https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#envoy-api-field-route-corspolicy-filter-enabled