### PR TITLE
Add generated code eval test

### DIFF
--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -26,6 +26,8 @@
     "command-exists": "^1.2.7",
     "google-closure-compiler": "^20180716.0.0",
     "google-protobuf": "^3.6.1",
+    "gulp": "^4.0.0",
+    "gulp-eval": "^1.0.0",
     "mocha": "^5.2.0",
     "mock-xmlhttprequest": "^2.0.0",
     "require-self": "^0.2.1",

--- a/packages/grpc-web/test/eval_test.js
+++ b/packages/grpc-web/test/eval_test.js
@@ -21,14 +21,14 @@ const execSync = require('child_process').execSync;
 const commandExists = require('command-exists').sync;
 const fs = require('fs');
 const path = require('path');
+const removeDirectory = require('./common.js').removeDirectory;
+const GENERATED_CODE_PATH = require('./common.js').GENERATED_CODE_PATH;
 
 describe('grpc-web generated code eval test (commonjs+dts)', function() {
-  const genCodePath = path.resolve(__dirname, './foo_grpc_web_pb.js');
-
   const genCodeCmd =
     'protoc -I=./test/protos foo.proto models.proto ' +
-    '--js_out=import_style=commonjs:./test ' +
-    '--grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:./test';
+    '--js_out=import_style=commonjs:./test/generated ' +
+    '--grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:./test/generated';
 
   before(function() {
     ['protoc', 'protoc-gen-grpc-web'].map(prog => {
@@ -39,23 +39,16 @@ describe('grpc-web generated code eval test (commonjs+dts)', function() {
   });
 
   beforeEach(function() {
-    [genCodePath].map(f => {
-       if (fs.existsSync(f)) {
-         fs.unlinkSync(f);
-       }
-     });
+    removeDirectory(path.resolve(__dirname, GENERATED_CODE_PATH));
+    fs.mkdirSync(path.resolve(__dirname, GENERATED_CODE_PATH));
   });
 
   afterEach(function() {
-    [genCodePath].map(f => {
-       if (fs.existsSync(f)) {
-         fs.unlinkSync(f);
-       }
-     });
+    removeDirectory(path.resolve(__dirname, GENERATED_CODE_PATH));
   });
 
   it('should eval', function() {
     execSync(genCodeCmd);
-    execSync(`npx gulp --gulpfile ./test/gulpfile.js`);
+    execSync(`npx gulp --gulpfile ./test/gulpfile.js gen-code-eval-test`);
   })
 });

--- a/packages/grpc-web/test/eval_test.js
+++ b/packages/grpc-web/test/eval_test.js
@@ -1,0 +1,61 @@
+/**
+ *
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+const assert = require('assert');
+const execSync = require('child_process').execSync;
+const commandExists = require('command-exists').sync;
+const fs = require('fs');
+const path = require('path');
+
+describe('grpc-web generated code eval test (commonjs+dts)', function() {
+  const genCodePath = path.resolve(__dirname, './foo_grpc_web_pb.js');
+
+  const genCodeCmd =
+    'protoc -I=./test/protos foo.proto models.proto ' +
+    '--js_out=import_style=commonjs:./test ' +
+    '--grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:./test';
+
+  before(function() {
+    ['protoc', 'protoc-gen-grpc-web'].map(prog => {
+      if (!commandExists(prog)) {
+        assert.fail(`${prog} is not installed`);
+      }
+    });
+  });
+
+  beforeEach(function() {
+    [genCodePath].map(f => {
+       if (fs.existsSync(f)) {
+         fs.unlinkSync(f);
+       }
+     });
+  });
+
+  afterEach(function() {
+    [genCodePath].map(f => {
+       if (fs.existsSync(f)) {
+         fs.unlinkSync(f);
+       }
+     });
+  });
+
+  it('should eval', function() {
+    execSync(genCodeCmd);
+    execSync(`npx gulp --gulpfile ./test/gulpfile.js`);
+  })
+});

--- a/packages/grpc-web/test/gulpfile.js
+++ b/packages/grpc-web/test/gulpfile.js
@@ -1,0 +1,6 @@
+const gulp = require('gulp');
+const gulpEval = require('gulp-eval');
+gulp.task('default', () =>
+  gulp.src('./foo_grpc_web_pb.js')
+      .pipe(gulpEval())
+);

--- a/packages/grpc-web/test/gulpfile.js
+++ b/packages/grpc-web/test/gulpfile.js
@@ -1,6 +1,7 @@
 const gulp = require('gulp');
 const gulpEval = require('gulp-eval');
-gulp.task('default', () =>
-  gulp.src('./foo_grpc_web_pb.js')
+
+gulp.task('gen-code-eval-test', () =>
+  gulp.src('./generated/foo_grpc_web_pb.js')
       .pipe(gulpEval())
 );

--- a/packages/grpc-web/test/protos/foo.proto
+++ b/packages/grpc-web/test/protos/foo.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package Foo;
+
+import "models.proto";
+
+message SimpleRequest {
+  string message = 1;
+}
+
+service FooService {
+  rpc EchoEmpty(SimpleRequest) returns (models.SimpleMessage);
+}

--- a/packages/grpc-web/test/protos/models.proto
+++ b/packages/grpc-web/test/protos/models.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+package models;
+
+message SimpleMessage {
+}


### PR DESCRIPTION
Added a test to make sure bugs like #596 don't happen again.

The test attempts to generate the client stub class with `import_style=commonjs+dts`, with some `import` statements in the `.proto` file. The generated `_grpc_web_pb.js` file should `eval()` properly without undefined variables.