### PR TITLE
Fix status and error callbacks

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -198,13 +198,13 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
     if (lastErrorCode != ErrorCode.NO_ERROR) {
       switch (lastErrorCode) {
         case ErrorCode.ABORT:
-          grpcStatusCode = StatusCode.ABORTED
+          grpcStatusCode = StatusCode.ABORTED;
           break;
         case ErrorCode.TIMEOUT:
-          grpcStatusCode = StatusCode.DEADLINE_EXCEEDED
+          grpcStatusCode = StatusCode.DEADLINE_EXCEEDED;
           break;
         default:
-          grpcStatusCode = StatusCode.UNAVAILABLE
+          grpcStatusCode = StatusCode.UNAVAILABLE;
       }
       if (grpcStatusCode == StatusCode.ABORTED && self.aborted_) {
         return;

--- a/net/grpc/gateway/examples/echo/node-server/package.json
+++ b/net/grpc/gateway/examples/echo/node-server/package.json
@@ -5,7 +5,7 @@
     "@grpc/proto-loader": "^0.3.0",
     "async": "^1.5.2",
     "google-protobuf": "^3.6.0",
-    "grpc": "^1.15.0",
+    "@grpc/grpc-js": "^0.5.0",
     "lodash": "^4.6.1"
   }
 }

--- a/net/grpc/gateway/examples/echo/node-server/server.js
+++ b/net/grpc/gateway/examples/echo/node-server/server.js
@@ -18,9 +18,10 @@
 
 var PROTO_PATH = __dirname + '/../echo.proto';
 
+var assert = require('assert');
 var async = require('async');
 var _ = require('lodash');
-var grpc = require('grpc');
+var grpc = require('@grpc/grpc-js');
 var protoLoader = require('@grpc/proto-loader');
 var packageDefinition = protoLoader.loadSync(
     PROTO_PATH,
@@ -89,8 +90,8 @@ function doServerStreamingEcho(call) {
 }
 
 /**
- * Get a new server with the handler functions in this file bound to the methods
- * it serves.
+ * Get a new server with the handler functions in this file bound to the
+ * methods it serves.
  * @return {!Server} The new server object
  */
 function getServer() {
@@ -106,8 +107,11 @@ function getServer() {
 if (require.main === module) {
   // If this is run as a script, start a server on an unused port
   var echoServer = getServer();
-  echoServer.bind('0.0.0.0:9090', grpc.ServerCredentials.createInsecure());
-  echoServer.start();
+  echoServer.bindAsync('0.0.0.0:9090', grpc.ServerCredentials.createInsecure(),
+                       (err, port) => {
+    assert.ifError(err);
+    echoServer.start();
+  });
 }
 
 exports.getServer = getServer;

--- a/net/grpc/gateway/examples/echo/ts-example/client.ts
+++ b/net/grpc/gateway/examples/echo/ts-example/client.ts
@@ -31,10 +31,13 @@ import {EchoRequest, EchoResponse, ServerStreamingEchoRequest, ServerStreamingEc
 class EchoApp {
   static readonly INTERVAL = 500;  // ms
   static readonly MAX_STREAM_MESSAGES = 50;
+
   echoService_: EchoServiceClient;
+  stream: grpcWeb.ClientReadableStream<ServerStreamingEchoResponse> | null;
 
   constructor(echoService: EchoServiceClient) {
     this.echoService_ = echoService;
+    this.stream = null;
   }
 
   static addMessage(message: string, cssClass: string) {
@@ -76,19 +79,26 @@ class EchoApp {
     });
   }
 
-  echoError(msg: string) {
-    EchoApp.addLeftMessage(msg);
+  echoError() {
+    EchoApp.addLeftMessage('Error');
     const request = new EchoRequest();
-    request.setMessage(msg);
+    request.setMessage('error');
     this.echoService_.echoAbort(
-        request, {}, (err: grpcWeb.Error, response: EchoResponse) => {
-          if (err) {
-            if (err.code !== grpcWeb.StatusCode.OK) {
-              EchoApp.addRightMessage(
-                  'Error code: ' + err.code + ' "' + err.message + '"');
-            }
+      request, {}, (err: grpcWeb.Error, response: EchoResponse) => {
+        if (err) {
+          if (err.code !== grpcWeb.StatusCode.OK) {
+            EchoApp.addRightMessage(
+              'Error code: ' + err.code + ' "' + decodeURI(err.message) + '"');
           }
-        });
+        }
+      });
+  }
+
+  cancel() {
+    EchoApp.addLeftMessage('Cancel');
+    if (this.stream) {
+      this.stream.cancel();
+    }
   }
 
   repeatEcho(msg: string, count: number) {
@@ -101,23 +111,23 @@ class EchoApp {
     request.setMessageCount(count);
     request.setMessageInterval(EchoApp.INTERVAL);
 
-    const stream = this.echoService_.serverStreamingEcho(
+    this.stream = this.echoService_.serverStreamingEcho(
         request, {'custom-header-1': 'value1'});
     const self = this;
-    stream.on('data', (response: ServerStreamingEchoResponse) => {
+    this.stream.on('data', (response: ServerStreamingEchoResponse) => {
       EchoApp.addRightMessage(response.getMessage());
     });
-    stream.on('status', (status: grpcWeb.Status) => {
+    this.stream.on('status', (status: grpcWeb.Status) => {
       if (status.metadata) {
         console.log('Received metadata');
         console.log(status.metadata);
       }
     });
-    stream.on('error', (err: grpcWeb.Error) => {
+    this.stream.on('error', (err: grpcWeb.Error) => {
       EchoApp.addRightMessage(
           'Error code: ' + err.code + ' "' + err.message + '"');
     });
-    stream.on('end', () => {
+    this.stream.on('end', () => {
       console.log('stream end signal received');
     });
   }
@@ -132,11 +142,13 @@ class EchoApp {
       const count = msg.substr(0, msg.indexOf(' '));
       if (/^\d+$/.test(count)) {
         this.repeatEcho(msg.substr(msg.indexOf(' ') + 1), Number(count));
-      } else if (count === 'err') {
-        this.echoError(msg.substr(msg.indexOf(' ') + 1));
       } else {
         this.echo(msg);
       }
+    } else if (msg === 'error') {
+      this.echoError();
+    } else if (msg === 'cancel') {
+      this.cancel();
     } else {
       this.echo(msg);
     }


### PR DESCRIPTION
Changes introduced this PR:

 - If user initiated a `cancel()` on a stream, don't trigger an `error` callback for the `ABORTED` event. This is for #544 
 - Make sure we check whether the header key `grpc-status` and `grpc-header` are present in `getResponseHeaders()` before trying to access them. This is for #574 
 - Update the Node server example to use the `@grpc/grpc-js` package rather than the `grpc` package.
 - Add `cancel` to be a command in the Echo example. This will call `stream.cancel()`.