### PR TITLE
Change plugin name to grpc_web in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ For example, in MacOS, you can do:
 
 ```
 $ sudo mv ~/Downloads/protoc-gen-grpc-web-1.0.6-darwin-x86_64 \
-  /usr/local/bin/protoc-gen-grpc-web
-$ chmod +x /usr/local/bin/protoc-gen-grpc-web
+  /usr/local/bin/protoc-gen-grpc_web
+$ chmod +x /usr/local/bin/protoc-gen-grpc_web
 ```
 
 ## Client Configuration Options


### PR DESCRIPTION
`protoc` seems to be looking for the grpc_web plugin name instead of the grpc-web.

Current readme instructions results into:
```
protoc-gen-grpc_web: program not found or is not executable
````

Tested with protoc@3.9.1 on OSX.