### PR TITLE
uppercase only the filename, not the directory

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -1362,8 +1362,9 @@ class GrpcCodeGenerator : public CodeGenerator {
       generate_dts = true;
     } else if (import_style_str == "typescript") {
       import_style = ImportStyle::TYPESCRIPT;
-      file_name =
-          UppercaseFirstLetter(StripProto(file->name())) + "ServiceClientPb.ts";
+      string::size_type pos = file->name().rfind('/');
+      file_name = file->name().substr(0, pos + 1) +
+        UppercaseFirstLetter(StripProto(file->name().substr(pos+1))) + "ServiceClientPb.ts";
     } else {
       *error = "options: invalid import_style - " + import_style_str;
       return false;


### PR DESCRIPTION
Currently this translates "foo/bar.proto" into
"Foo/barServiceClientPb.ts". After this change it will be the correct
"foo/BarServiceClientPb.ts" instead.