### PR TITLE
Latest closure compiler broke test

### DIFF
--- a/net/grpc/gateway/docker/closure_client/Dockerfile
+++ b/net/grpc/gateway/docker/closure_client/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -qq update && apt-get -qq install -y \
   default-jdk
 
 RUN cd /github/grpc-web && \
-  curl -sS https://dl.google.com/closure-compiler/compiler-latest.zip \
+  curl -sS https://dl.google.com/closure-compiler/compiler-20190909.zip \
   -o /github/grpc-web/compiler-latest.zip
 
 RUN cd /github/grpc-web && \


### PR DESCRIPTION
The latest closure compiler release `20190929` seems to have broken our tests.

A bunch of these errors:

```
../../../../../third_party/closure-library/closure/goog/array/array.js:42: ERROR - [JSC_DEFINE_CALL_WITHOUT_A\
SSIGNMENT] The result of a goog.define call must be assigned as an isolated statement.                        
goog.define('goog.NATIVE_ARRAY_PROTOTYPES', goog.TRUSTED_SITE);                                               
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
```

Temporarily pinning our tests to an earlier version of the closure compiler `20190909`