### PR TITLE
Use closure compiler from npm in build.js

### DIFF
--- a/packages/grpc-web/scripts/build.js
+++ b/packages/grpc-web/scripts/build.js
@@ -42,7 +42,8 @@ const closureArgs = [].concat(
   ]
 );
 
-const closureCommand = "google-closure-compiler " + closureArgs.join(' ');
+const closureCompilerBin = path.resolve(__dirname, "../node_modules/.bin/google-closure-compiler");
+const closureCommand = closureCompilerBin + " " + closureArgs.join(' ');
 
 console.log(closureCommand);
 let child = exec(closureCommand);


### PR DESCRIPTION
This use the script npm generate in `.bin` inside `build.js` so that the version align and a global install isn't necessary.