### PR TITLE
Ensure that the end callback is called

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -37,7 +37,6 @@ const EventType = goog.require('goog.net.EventType');
 const GrpcWebStreamParser = goog.require('grpc.web.GrpcWebStreamParser');
 const StatusCode = goog.require('grpc.web.StatusCode');
 const XhrIo = goog.require('goog.net.XhrIo');
-const XmlHttp = goog.require('goog.net.XmlHttp');
 const events = goog.require('goog.events');
 const googCrypt = goog.require('goog.crypt.base64');
 const googString = goog.require('goog.string');

--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -179,14 +179,6 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
         }
       }
     }
-
-    var readyState = self.xhr_.getReadyState();
-    if (readyState == XmlHttp.ReadyState.COMPLETE) {
-      if (self.onEndCallback_) {
-        self.onEndCallback_();
-      }
-      return;
-    }
   });
 
   events.listen(this.xhr_, EventType.COMPLETE, function(e) {
@@ -221,6 +213,8 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
       return;
     }
 
+    var errorEmitted = false;
+
     // Check whethere there are grpc specific response headers
     var responseHeaders = self.xhr_.getResponseHeaders();
     if (GRPC_STATUS in responseHeaders) {
@@ -233,12 +227,19 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
           code: Number(grpcStatusCode),
           message: grpcStatusMessage,
         });
+        errorEmitted = true;
       }
       if (self.onStatusCallback_) {
         self.onStatusCallback_(/** @type {!Status} */ ({
           code: Number(grpcStatusCode),
           details: grpcStatusMessage,
         }));
+      }
+    }
+
+    if (!errorEmitted) {
+      if (self.onEndCallback_) {
+        self.onEndCallback_();
       }
     }
   });


### PR DESCRIPTION
This should fix the case where a server stream was closed by some element on the network (Like envoy proxy with a timeout configured) and grpc-web didn't report any even (Neither 'error' or 'end') this fixes for us symptoms similar to #543 (We also see ERR_INCOMPLETE_CHUNKED_ENCODING more rarely like #361 but don't have a good solution yet) 

Previously the end callback was called by checking the state at the end of the `READY_STATE_CHANGE` event.

The problem with this approach is that there are multiple early exit cases in this function and when they happen the consumer is never informed of the end of the stream.

The new approach is to only dispatch the event when the `COMPLETE` event is received (Except if an error is dispatched) so the last event is always either `'error'` or `'end'`).

I'd like feedback on this last point as I did the 'only error or end' part by feeling but couldn't find any specification of how it's supposed to work, the other choices being to send error + end when an error is detected.