### PR TITLE
Add config for Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,6 +15,6 @@ platforms:
 
   ubuntu1804:
     build_targets:
-      - "//..."
+      - //...
     test_targets:
       - //...

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,20 @@
+---
+# TODO(yannic): Enable buildifier and test on Windows and RBE (both unsupported by rules_closure).
+platforms:
+  macos:
+    build_targets:
+      - //...
+    test_targets:
+      - //...
+
+  ubuntu1604:
+    build_targets:
+      - //...
+    test_targets:
+      - //...
+
+  ubuntu1804:
+    build_targets:
+      - "//..."
+    test_targets:
+      - //...


### PR DESCRIPTION
This will ensure gRPC-Web is compatible with the latest Bazel.
If we enable presubmit testing, we can remove Bazel from Kokoro
and speed-up CI.