### PR TITLE
Optimise parsing incoming payload

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -137,7 +137,7 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
     } else {
       return;
     }
-    var messages = self.parser_.parse([].slice.call(byteSource));
+    var messages = self.parser_.parse(byteSource);
     if (messages) {
       var FrameType = GrpcWebStreamParser.FrameType;
       for (var i = 0; i < messages.length; i++) {

--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -137,7 +137,7 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
     } else {
       return;
     }
-    var messages = self.parser_.parse(byteSource);
+    var messages = self.parser_.parse(byteSource.buffer);
     if (messages) {
       var FrameType = GrpcWebStreamParser.FrameType;
       for (var i = 0; i < messages.length; i++) {


### PR DESCRIPTION
It seems redundant to copy the whole `byteSource` before parsing it. 

In our case, with `format: binary` and the payload size of 50mb this creates a lot of overhead. With our tests, that slice causes extra ~10s of processing time for a 50mb payload.

I’m keen to hear your opinions about this change.