### PR TITLE
Revert #683

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -137,7 +137,7 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
     } else {
       return;
     }
-    var messages = self.parser_.parse(byteSource.buffer);
+    var messages = self.parser_.parse([].slice.call(byteSource));
     if (messages) {
       var FrameType = GrpcWebStreamParser.FrameType;
       for (var i = 0; i < messages.length; i++) {


### PR DESCRIPTION
See https://github.com/grpc/grpc-web/pull/683#issuecomment-561999180.

In summary: when we pass the xhr response to our grpc-web parser, the underlying backing `ArrayBuffer` could have a larger `.byteLength` than the actual size of the array filled (i.e. the `.length` of the `Uint8Array` view). So we cannot just pass the backing `ArrayBuffer` to the parser. We need to find another solution to avoid the array copy operation.

Reverting #683 for now.