### PR TITLE
Fix issue 632 (double execution of callback)

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -229,7 +229,7 @@ const GrpcWebClientReadableStream = function(genericTransportInterface) {
         });
         errorEmitted = true;
       }
-      if (self.onStatusCallback_) {
+      if (!errorEmitted && self.onStatusCallback_) {
         self.onStatusCallback_(/** @type {!Status} */ ({
           code: Number(grpcStatusCode),
           details: grpcStatusMessage,

--- a/net/grpc/gateway/examples/echo/node-server/package.json
+++ b/net/grpc/gateway/examples/echo/node-server/package.json
@@ -5,7 +5,7 @@
     "@grpc/proto-loader": "^0.3.0",
     "async": "^1.5.2",
     "google-protobuf": "^3.6.0",
-    "@grpc/grpc-js": "^0.5.0",
+    "grpc": "^1.24.0",
     "lodash": "^4.6.1"
   }
 }

--- a/net/grpc/gateway/examples/echo/node-server/server.js
+++ b/net/grpc/gateway/examples/echo/node-server/server.js
@@ -21,7 +21,7 @@ var PROTO_PATH = __dirname + '/../echo.proto';
 var assert = require('assert');
 var async = require('async');
 var _ = require('lodash');
-var grpc = require('@grpc/grpc-js');
+var grpc = require('grpc');
 var protoLoader = require('@grpc/proto-loader');
 var packageDefinition = protoLoader.loadSync(
     PROTO_PATH,


### PR DESCRIPTION
This fixes that a grpc-status in the response header resulted in double execution of the callback that was provided to the rpcCall (https://github.com/grpc/grpc-web/issues/632)

In the echoAbort exampl to test grpc error response codes, this bug (https://github.com/grpc/grpc-web/issues/632) was not hit, because the used server library (grpc-js) is not fully compliant with other grpc server libraries. It seems that the grpc-js library is not sending grpc-status response headers in the same way as the golang, c++ implementations or that these headers are removed by envoy if grpc-js is used (this needs to be confirmed separately). In my tests, I found that simply changing the npm package to the native "grpc" library in the provided examples would result in the bug mentioned above. Therefore, I suggest to switch to the grpc npm package in the examples (i.e. grpc-js is still in beta).