### PR TITLE
Allow "commonjs" as import_style

### DIFF
--- a/bazel/closure_grpc_web_library.bzl
+++ b/bazel/closure_grpc_web_library.bzl
@@ -135,7 +135,7 @@ def _closure_grpc_web_library_impl(ctx):
         "reportUnknownTypes",
         "strictDependencies",
         "extraRequire",
-        "superfluousSuppress,
+        "superfluousSuppress",
     ]
 
     library = create_closure_js_library(

--- a/bazel/closure_grpc_web_library.bzl
+++ b/bazel/closure_grpc_web_library.bzl
@@ -162,7 +162,7 @@ closure_grpc_web_library = rule(
         ),
         "import_style": attr.string(
             default = "closure",
-            values = ["closure"],
+            values = ["closure", "commonjs"],
         ),
         "mode": attr.string(
             default = "grpcwebtext",

--- a/bazel/closure_grpc_web_library.bzl
+++ b/bazel/closure_grpc_web_library.bzl
@@ -135,6 +135,7 @@ def _closure_grpc_web_library_impl(ctx):
         "reportUnknownTypes",
         "strictDependencies",
         "extraRequire",
+        "superfluousSuppress,
     ]
 
     library = create_closure_js_library(


### PR DESCRIPTION
Allows the specification of "commonjs" as an import style, as documented here: https://github.com/grpc/grpc-web#import-style