### PR TITLE
allow_origin is deprecated in latest envoy server

### DIFF
--- a/net/grpc/gateway/examples/echo/envoy.yaml
+++ b/net/grpc/gateway/examples/echo/envoy.yaml
@@ -25,8 +25,8 @@ static_resources:
                   cluster: echo_service
                   max_grpc_timeout: 0s
               cors:
-                allow_origin:
-                - "*"
+                allow_origin_string_match:
+                - prefix: "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"

--- a/net/grpc/gateway/examples/helloworld/README.md
+++ b/net/grpc/gateway/examples/helloworld/README.md
@@ -116,8 +116,8 @@ static_resources:
                   cluster: greeter_service
                   max_grpc_timeout: 0s
               cors:
-                allow_origin:
-                - "*"
+                allow_origin_string_match:
+                - prefix: "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"

--- a/net/grpc/gateway/examples/helloworld/envoy.yaml
+++ b/net/grpc/gateway/examples/helloworld/envoy.yaml
@@ -25,8 +25,8 @@ static_resources:
                   cluster: greeter_service
                   max_grpc_timeout: 0s
               cors:
-                allow_origin:
-                - "*"
+                allow_origin_string_match:
+                - prefix: "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"


### PR DESCRIPTION
`allow_origin` configuration has been deprecated in favour of `allow_origin_string_match`

The latest version of envoy proxy will not start if `allow_origin` option is used