### PR TITLE
Use the standard javascript 'Error' object for rpc call failures

### DIFF
--- a/javascript/net/grpc/web/BUILD.bazel
+++ b/javascript/net/grpc/web/BUILD.bazel
@@ -120,6 +120,7 @@ closure_js_library(
     visibility = ["//visibility:public"],
     deps = [
         ":clientreadablestream",
+        ":error",
         ":generictransportinterface",
         ":grpcwebstreamparser",
         ":status",

--- a/javascript/net/grpc/web/streambodyclientreadablestream.js
+++ b/javascript/net/grpc/web/streambodyclientreadablestream.js
@@ -153,13 +153,13 @@ const StreamBodyClientReadableStream = function(genericTransportInterface) {
         grpcStatusCode = StatusCode.UNAVAILABLE;
     }
 
-    self.onErrorCallback_({
-      code: grpcStatusCode,
-      // TODO(armiller): get the message from the response?
-      // GoogleRpcStatus.deserialize(rawResponse).getMessage()?
-      // Perhaps do the same status logic as in on('data') above?
-      message: ErrorCode.getDebugMessage(lastErrorCode)
-    });
+    // TODO(armiller): get the message from the response?
+    // GoogleRpcStatus.deserialize(rawResponse).getMessage()?
+    // Perhaps do the same status logic as in on('data') above?
+    var message = ErrorCode.getDebugMessage(lastErrorCode);
+    var errorObject = /** @type {!GrpcWebError} */ (new Error(message));
+    errorObject.code = grpcStatusCode;
+    self.onErrorCallback_(errorObject);
   });
 };
 


### PR DESCRIPTION
This change ensure that the error object passed to `rpcCall` callback, that is also the object provided to the reject method in promise form, is an instance of the `Error` class.

The advantage is that we now get a callstack in the error object for better debugging.

The properties other that the `message` one (Already present on error) are added to the instance, so the interface of the resulting object is the same as before, only with additional properties.

I didn't specifically subclass `Error` as it's problematic compatibility-wise so I did a typedef + cast for Closure. It's the first time I really have to do anything with the Closure compiler so this might not be a correct way to do it...