### PR TITLE
moving envoy back to :latest

### DIFF
--- a/net/grpc/gateway/docker/envoy/Dockerfile
+++ b/net/grpc/gateway/docker/envoy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM envoyproxy/envoy:v1.12.2
+FROM envoyproxy/envoy:latest
 
 COPY net/grpc/gateway/examples/echo/envoy.yaml /etc/envoy/envoy.yaml
 


### PR DESCRIPTION
After the fix in #716 , moving the envoy docker base image to `:latest`.