### PR TITLE
Fix grpcwebproxy interop

### DIFF
--- a/net/grpc/gateway/docker/grpcwebproxy/Dockerfile
+++ b/net/grpc/gateway/docker/grpcwebproxy/Dockerfile
@@ -17,7 +17,7 @@ FROM golang:alpine
 RUN apk add --no-cache curl git ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 
-ARG VERSION=0.11.0
+ARG VERSION=0.12.0
 
 WORKDIR /tmp
 
@@ -31,7 +31,7 @@ RUN mv grpc-web-$VERSION grpc-web
 
 WORKDIR /go/src/github.com/improbable-eng/grpc-web
 
-RUN dep ensure --vendor-only && \
+RUN dep ensure && \
   go install ./go/grpcwebproxy
 
 ADD ./etc/localhost.crt /etc


### PR DESCRIPTION
Back to be able to interop with [grpcwebproxy](https://github.com/improbable-eng/grpc-web), after https://github.com/improbable-eng/grpc-web/issues/568 was fixed.

Now this `docker-compose -f advanced.yml up node-server grpcwebproxy binary-client` is back to working correctly.