### PR TITLE
Disable static checkers on generated js files

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -1013,7 +1013,9 @@ void PrintFileHeader(Printer* printer, const std::map<string, string>& vars) {
       " * @enhanceable\n"
       " * @public\n"
       " */\n\n"
-      "// GENERATED CODE -- DO NOT EDIT!\n\n\n");
+      "// GENERATED CODE -- DO NOT EDIT!\n\n\n"
+      "/* eslint-disable */"
+      "//@ts-nocheck\n\n\n");
 }
 
 void PrintMethodDescriptorFile(Printer* printer,
@@ -1025,7 +1027,9 @@ void PrintMethodDescriptorFile(Printer* printer,
       " * @enhanceable\n"
       " * @public\n"
       " */\n\n"
-      "// GENERATED CODE -- DO NOT EDIT!\n\n\n");
+      "// GENERATED CODE -- DO NOT EDIT!\n\n\n"
+      "/* eslint-disable */"
+      "//@ts-nocheck\n\n\n");
 
   printer->Print(vars,
                  "goog.provide('proto.$package_dot$$class_name$.$"


### PR DESCRIPTION
This will work as a hotfix for #447

I think it could make sense to include it.
Since those are auto generated they never should be edited so it would be ok disable static checkers.

**Eslint:**
https://eslint.org/docs/2.13.1/user-guide/configuring#disabling-rules-with-inline-comments
**Typescript**
https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html