### PR TITLE
Fix unit test

### DIFF
--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-web",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "Google Inc.",
   "description": "gRPC-Web Client Runtime Library",
   "homepage": "https://grpc.io/",
@@ -30,7 +30,7 @@
     "gulp-eval": "^1.0.0",
     "mocha": "^5.2.0",
     "mock-xmlhttprequest": "^2.0.0",
-    "require-self": "^0.2.1",
-    "typescript": "^3.2.1"
+    "require-self": "0.2.1",
+    "typescript": "~3.7.0"
   }
 }


### PR DESCRIPTION
Fixes #754 

This fixes a recent unit test breakage. Apparently the `require-self` package has been updated and is causing the breakage. 

It used to produce a file `grpc-web.js` with one line
```
module.exports = require('/usr/local/google/home/stanleycheung/grpc-web/packages/grpc-web');
```

Now it also produces a new file `grpc-web.d.ts`, with this one line
```
export * from '/usr/local/google/home/stanleycheung/grpc-web/packages/grpc-web';
```

Apparently the latter is causing the problem. Pinning `require-self` to version `0.2.1` fixes the unit test breakage.