### PR TITLE
Update google closure compiler

### DIFF
--- a/packages/grpc-web/exports.js
+++ b/packages/grpc-web/exports.js
@@ -12,10 +12,8 @@ const StatusCode = goog.require('grpc.web.StatusCode');
 const MethodDescriptor = goog.require('grpc.web.MethodDescriptor');
 const MethodType = goog.require('grpc.web.MethodType');
 
-const exports = module['exports'];
-
-exports['AbstractClientBase'] = {'MethodInfo': AbstractClientBase.MethodInfo};
-exports['GrpcWebClientBase'] = GrpcWebClientBase;
-exports['StatusCode'] = StatusCode;
-exports['MethodDescriptor'] = MethodDescriptor;
-exports['MethodType'] = MethodType;
+module['exports']['AbstractClientBase'] = {'MethodInfo': AbstractClientBase.MethodInfo};
+module['exports']['GrpcWebClientBase'] = GrpcWebClientBase;
+module['exports']['StatusCode'] = StatusCode;
+module['exports']['MethodDescriptor'] = MethodDescriptor;
+module['exports']['MethodType'] = MethodType;

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -23,14 +23,14 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "command-exists": "^1.2.7",
-    "google-closure-compiler": "^20190909.0.0",
-    "google-protobuf": "^3.8.0",
-    "gulp": "^4.0.0",
-    "gulp-eval": "^1.0.0",
-    "mocha": "^5.2.0",
-    "mock-xmlhttprequest": "^2.0.0",
+    "command-exists": "~1.2.8",
+    "google-closure-compiler": "~20200224.0.0",
+    "google-protobuf": "~3.11.4",
+    "gulp": "~4.0.2",
+    "gulp-eval": "~1.0.0",
+    "mocha": "~5.2.0",
+    "mock-xmlhttprequest": "~2.0.0",
     "require-self": "0.2.1",
-    "typescript": "~3.7.0"
+    "typescript": "~3.8.0"
   }
 }

--- a/packages/grpc-web/scripts/build.js
+++ b/packages/grpc-web/scripts/build.js
@@ -34,7 +34,7 @@ const closureArgs = [].concat(
   [
     `--entry_point=grpc.web.Exports`,
     `--externs=externs.js`,
-    `--dependency_mode=STRICT`,
+    `--dependency_mode=PRUNE`,
     `--compilation_level=ADVANCED_OPTIMIZATIONS`,
     `--generate_exports`,
     `--export_local_property_definitions`,

--- a/packages/grpc-web/test/generated_code_test.js
+++ b/packages/grpc-web/test/generated_code_test.js
@@ -258,7 +258,7 @@ describe('grpc-web generated code (closure+grpcwebtext)', function() {
     jsPaths.map(jsPath => `--js=${jsPath}`),
     [
       `--entry_point=goog:proto.grpc.gateway.testing.EchoAppClient`,
-      `--dependency_mode=STRICT`,
+      `--dependency_mode=PRUNE`,
       `--js_output_file ./test/generated/compiled.js`,
       `--output_wrapper="%output%module.exports = proto.grpc.gateway.testing;"`,
     ]


### PR DESCRIPTION
While working on #755, we noticed that our npm packages dependency might be a bit too loose. So here I am switching them to tildas (~) so that we stay on the current minor version. 

While doing that, and updating to use the latest [google-closure-compiler release](https://github.com/google/closure-compiler/wiki/Releases#january-1-2020-v20200101), I noticed that a flag `--dependency_mode` has been changed so I have to do some related changes there. 