### PR TITLE
Update generic client

### DIFF
--- a/javascript/net/grpc/web/BUILD.bazel
+++ b/javascript/net/grpc/web/BUILD.bazel
@@ -33,8 +33,19 @@ closure_js_library(
     deps = [
         ":clientreadablestream",
         ":error",
-        ":methoddescriptor",
+        ":requester",
     ],
+)
+
+closure_js_library(
+    name = "calloptions",
+    srcs = [
+        "calloptions.js",
+    ],
+    suppress = [
+        "reportUnknownTypes",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 closure_js_library(
@@ -137,22 +148,29 @@ closure_js_library(
 )
 
 closure_js_library(
-    name = "methoddescriptor",
-    srcs = [
-        "methoddescriptor.js",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":methodtype",
-    ],
-)
-
-closure_js_library(
     name = "methodtype",
     srcs = [
         "methodtype.js",
     ],
     visibility = ["//visibility:public"],
+)
+
+closure_js_library(
+    name = "requester",
+    srcs = [
+        "methoddescriptor.js",
+        "request.js",
+        "requestinternal.js",
+    ],
+    suppress = [
+        "reportUnknownTypes",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":calloptions",
+        ":metadata",
+        ":methodtype",
+    ],
 )
 
 closure_js_library(

--- a/javascript/net/grpc/web/genericclient.js
+++ b/javascript/net/grpc/web/genericclient.js
@@ -5,9 +5,8 @@
 goog.module('grpc.web.GenericClient');
 goog.module.declareLegacyNamespace();
 
-const CallOptions = goog.require('grpc.web.CallOptions');
-const Metadata = goog.require('grpc.web.Metadata');
 const MethodDescriptor = goog.require('grpc.web.MethodDescriptor');
+const Request = goog.require('grpc.web.Request');
 const UnaryResponse = goog.require('grpc.web.UnaryResponse');
 
 /**
@@ -17,31 +16,26 @@ const GenericClient = function() {};
 
 
 /**
- * @param {!REQUEST} request The request proto message
- * @param {!MethodDescriptor<REQUEST, RESPONSE>} methodDescriptor Information of
- *     this RPC method
- * @param {!Metadata} metadata The user defined request metadata.
- * @param {!CallOptions} callOptions
+ * @param {!Request<REQUEST, RESPONSE>} request The wrapped gRPC-Web request
  * @return {!Promise<!UnaryResponse<RESPONSE>>} A promise that resolves to the
  *     response message and metadata
  * @template REQUEST, RESPONSE
  * @abstract
  */
-GenericClient.prototype.unaryCall = function(
-    request, methodDescriptor, metadata, callOptions) {};
+GenericClient.prototype.unaryCall = function(request) {};
 
 /**
- * @param {!REQUEST} request The request proto message
+ * Simplified version of GenericClient.prototype.unaryCall. Users are expected
+ * to use this method if they don't have the need to customize metadata and
+ * callOptions .
+ * @param {!REQUEST} requestMessage The request message
  * @param {!MethodDescriptor<REQUEST, RESPONSE>} methodDescriptor Information of
  *     this RPC method
- * @param {!Metadata=} metadata The user defined request metadata.
- * @param {!CallOptions=} callOptions
  * @return {!Promise<RESPONSE>} A promise that resolves to the
  *     response message
  * @template REQUEST, RESPONSE
  * @abstract
  */
-GenericClient.prototype.call = function(
-    request, methodDescriptor, metadata = {}, callOptions) {};
+GenericClient.prototype.call = function(requestMessage, methodDescriptor) {};
 
 exports = GenericClient;

--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -1069,7 +1069,9 @@ void PrintMethodDescriptorFile(Printer* printer,
   printer->Print(vars, "goog.require('grpc.web.MethodDescriptor');\n");
   printer->Print(vars, "goog.require('grpc.web.MethodType');\n");
   printer->Print(vars, "goog.require('$in_type$');\n");
-  printer->Print(vars, "goog.require('$out_type$');\n");
+  if (vars["out_type"] != vars["in_type"]) {
+    printer->Print(vars, "goog.require('$out_type$');\n");
+  }
   printer->Print(vars, "\n\ngoog.scope(function() {\n\n");
 
   printer->Print(

--- a/javascript/net/grpc/web/methoddescriptor.js
+++ b/javascript/net/grpc/web/methoddescriptor.js
@@ -7,7 +7,11 @@
 goog.module('grpc.web.MethodDescriptor');
 goog.module.declareLegacyNamespace();
 
+const CallOptions = goog.require('grpc.web.CallOptions');
+const Metadata = goog.require('grpc.web.Metadata');
 const MethodType = goog.require('grpc.web.MethodType');
+const Request = goog.require('grpc.web.Request');
+const RequestInternal = goog.require('grpc.web.RequestInternal');
 
 /**
  * @constructor
@@ -35,6 +39,18 @@ const MethodDescriptor = function(
   this.requestSerializeFn = requestSerializeFn;
   /** @const */
   this.responseDeserializeFn = responseDeserializeFn;
+};
+
+/**
+ * @template REQUEST, RESPONSE
+ * @param {REQUEST} requestMessage
+ * @param {!Metadata=} metadata
+ * @param {!CallOptions=} callOptions
+ * @return {!Request<REQUEST, RESPONSE>}
+ */
+MethodDescriptor.prototype.createRequest = function(
+    requestMessage, metadata = {}, callOptions = new CallOptions()) {
+  return new RequestInternal(requestMessage, this, metadata, callOptions);
 };
 
 exports = MethodDescriptor;

--- a/javascript/net/grpc/web/request.js
+++ b/javascript/net/grpc/web/request.js
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview  A wrapper class that provides all the information that is
+ * needed to make a gRPC-Web request.
+ */
+goog.module('grpc.web.Request');
+goog.module.declareLegacyNamespace();
+
+const CallOptions = goog.require('grpc.web.CallOptions');
+const Metadata = goog.require('grpc.web.Metadata');
+const MethodDescriptor = goog.requireType('grpc.web.MethodDescriptor');
+
+/**
+ * @interface
+ * @template REQUEST, RESPONSE
+ */
+class Request {
+  /** @return {REQUEST} */
+  getRequestMessage() {}
+
+  /** @return {!MethodDescriptor<REQUEST, RESPONSE>}*/
+  getMethodDescriptor() {}
+
+  /** @return {!Metadata} */
+  getMetadata() {}
+
+  /**
+   * Client CallOptions. Note that CallOptions has not been implemented in
+   * grpc.web.AbstractClientbase yet, but will be used in
+   * grpc.web.GenericClient.
+   * @return {!CallOptions|undefined}
+   */
+  getCallOptions() {}
+}
+
+exports = Request;

--- a/javascript/net/grpc/web/requestinternal.js
+++ b/javascript/net/grpc/web/requestinternal.js
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview Internal implementation of grpc.web.Request.
+ */
+goog.module('grpc.web.RequestInternal');
+goog.module.declareLegacyNamespace();
+
+const CallOptions = goog.require('grpc.web.CallOptions');
+const Metadata = goog.require('grpc.web.Metadata');
+const MethodDescriptor = goog.requireType('grpc.web.MethodDescriptor');
+const Request = goog.require('grpc.web.Request');
+
+/**
+ * @template REQUEST, RESPONSE
+ * @implements {Request<REQUEST, RESPONSE>}
+ * @final
+ * @package
+ */
+class RequestInternal {
+  /**
+   * @param {REQUEST} requestMessage
+   * @param {!MethodDescriptor<REQUEST, RESPONSE>} methodDescriptor
+   * @param {!Metadata} metadata
+   * @param {!CallOptions} callOptions
+   */
+  constructor(requestMessage, methodDescriptor, metadata, callOptions) {
+    /**
+     * @const {REQUEST}
+     * @private
+     */
+    this.requestMessage_ = requestMessage;
+
+    /**
+     * @const {!MethodDescriptor<REQUEST, RESPONSE>}
+     * @private
+     */
+    this.methodDescriptor_ = methodDescriptor;
+
+    /** @const @private */
+    this.metadata_ = metadata;
+
+    /** @const @private */
+    this.callOptions_ = callOptions;
+  }
+
+  /**
+   * @override
+   * @return {REQUEST}
+   */
+  getRequestMessage() {
+    return this.requestMessage_;
+  }
+
+  /**
+   * @override
+   * @return {!MethodDescriptor<REQUEST, RESPONSE>}
+   */
+  getMethodDescriptor() {
+    return this.methodDescriptor_;
+  }
+
+  /**
+   * @override
+   * @return {!Metadata}
+   */
+  getMetadata() {
+    return this.metadata_;
+  }
+
+  /**
+   * @override
+   * @return {!CallOptions|undefined}
+   */
+  getCallOptions() {
+    return this.callOptions_;
+  }
+}
+
+exports = RequestInternal;

--- a/javascript/net/grpc/web/unaryresponse.js
+++ b/javascript/net/grpc/web/unaryresponse.js
@@ -1,6 +1,6 @@
 /**
- * @fileoverview gRPC web client UnaryResponse returned the by grpc unary calls.
- * It consists of response message and response metadata(headers).
+ * @fileoverview gRPC web client UnaryResponse returned by grpc unary calls.
+ * Response meassage and metadata are included in UnaryResponse.
  */
 
 goog.module('grpc.web.UnaryResponse');
@@ -9,17 +9,36 @@ goog.module.declareLegacyNamespace();
 const Metadata = goog.require('grpc.web.Metadata');
 
 /**
- * @constructor
- * @struct
  * @template RESPONSE
- * @param {RESPONSE} message
- * @param {!Metadata=} metadata
  */
-const UnaryResponse = function(message, metadata) {
-  /** @const {RESPONSE} */
-  this.message = message;
-  /** @const {!Metadata|undefined} */
-  this.metadata = metadata;
-};
+class UnaryResponse {
+  /**
+   * @param {RESPONSE} responseMessage
+   * @param {!Metadata=} metadata
+   */
+  constructor(responseMessage, metadata = {}) {
+    /**
+     * @const {RESPONSE}
+     * @private
+     */
+    this.responseMessage_ = responseMessage;
+
+    /**
+     * @const {!Metadata}
+     * @private
+     */
+    this.metadata_ = metadata;
+  }
+
+  /** @return {RESPONSE} */
+  getResponseMessage() {
+    return this.responseMessage_;
+  }
+
+  /** @return {!Metadata} */
+  getMetadata() {
+    return this.metadata_;
+  }
+}
 
 exports = UnaryResponse;

--- a/javascript/net/grpc/web/util/genericpbjsclient.js
+++ b/javascript/net/grpc/web/util/genericpbjsclient.js
@@ -62,6 +62,8 @@ var GenericPbjsClient = function(hostname) {
  *
  * @param {!Object} method The method (a Protobuf.js Method object)
  * @return {string} The full name of the service containing the method
+ * @suppress {missingProperties}
+ * @suppress {strictMissingProperties}
  */
 function getServiceName(method) {
   var fullName = method.parent.fullName;
@@ -80,6 +82,8 @@ function getServiceName(method) {
  * @param {!Object<string, string>} metadata User defined call metadata
  * @param {function(?Error, ?Object)} callback A callback function
  *     which takes (error, response)
+ * @suppress {missingProperties}
+ * @suppress {strictMissingProperties}
  */
 GenericPbjsClient.prototype.rpcCall = function(
     method, request, metadata, callback) {


### PR DESCRIPTION
Update GenericClient, Request, UnaryResponse, MethodDescriptor

1. Create a new interface grpc.web.Request. We are eliminating a few arguments to make the formal Request object. It can only be instantiated by calling MethodDescriotor.createRequest.
2. Update unaryResponse so it's easier to be extended
3. Add the method createRequest to MethodDescriptor