### PR TITLE
Make kokoro run under macOS

### DIFF
--- a/scripts/kokoro.sh
+++ b/scripts/kokoro.sh
@@ -23,7 +23,11 @@ make clean
 
 # Lint bazel files.
 BUILDIFIER_VERSION=1.0.0
-wget "https://github.com/bazelbuild/buildtools/releases/download/${BUILDIFIER_VERSION}/buildifier"
+BUILDIFIER_SUFFIX=""
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  BUILDIFIER_SUFFIX=".mac"
+fi
+wget -O buildifier "https://github.com/bazelbuild/buildtools/releases/download/${BUILDIFIER_VERSION}/buildifier${BUILDIFIER_SUFFIX}"
 chmod +x "./buildifier"
 ./buildifier -version
 ./buildifier --mode=check --lint=warn --warnings=all -r bazel javascript net
@@ -42,10 +46,14 @@ docker-compose -f advanced.yml build
 
 # Run all bazel unit tests
 BAZEL_VERSION=2.2.0
-wget https://github.com/bazelbuild/bazel/releases/download/"${BAZEL_VERSION}"/bazel-"${BAZEL_VERSION}"-installer-linux-x86_64.sh
-chmod +x ./bazel-"${BAZEL_VERSION}"-installer-linux-x86_64.sh
-./bazel-"${BAZEL_VERSION}"-installer-linux-x86_64.sh --user
-rm ./bazel-"${BAZEL_VERSION}"-installer-linux-x86_64.sh
+BAZEL_OS="linux"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  BAZEL_OS="darwin"
+fi
+wget -O bazel-installer.sh https://github.com/bazelbuild/bazel/releases/download/"${BAZEL_VERSION}"/bazel-"${BAZEL_VERSION}"-installer-"${BAZEL_OS}"-x86_64.sh
+chmod +x ./bazel-installer.sh
+./bazel-installer.sh --user
+rm ./bazel-installer.sh
 $HOME/bin/bazel version
 $HOME/bin/bazel clean
 $HOME/bin/bazel test \


### PR DESCRIPTION
With this change kokoro download the `bazel` and `buildifier` binaries for mac when run under macOS