### PR TITLE
Add entrypoint for node-server

### DIFF
--- a/net/grpc/gateway/examples/echo/node-server/package.json
+++ b/net/grpc/gateway/examples/echo/node-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "grpc-web-node-server-example",
   "version": "0.1.0",
+  "main": "server.js",
   "dependencies": {
     "@grpc/proto-loader": "^0.3.0",
     "async": "^1.5.2",

--- a/net/grpc/gateway/examples/helloworld/package.json
+++ b/net/grpc/gateway/examples/helloworld/package.json
@@ -2,6 +2,7 @@
   "name": "grpc-web-simple-example",
   "version": "0.1.0",
   "description": "gRPC-Web simple example",
+  "main": "server.js",
   "devDependencies": {
     "@grpc/proto-loader": "^0.3.0",
     "async": "^1.5.2",


### PR DESCRIPTION
Trivial change that allows Node developers to run `node .` without having to know where the entry point is.