### PR TITLE
Use explicit envoy release tag

### DIFF
--- a/kokoro/master.cfg
+++ b/kokoro/master.cfg
@@ -1,0 +1,1 @@
+build_file: "grpc-web/scripts/kokoro.sh"

--- a/net/grpc/gateway/docker/envoy/Dockerfile
+++ b/net/grpc/gateway/docker/envoy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy:v1.14.1
 
 COPY net/grpc/gateway/examples/echo/envoy.yaml /etc/envoy/envoy.yaml
 


### PR DESCRIPTION
The `envoyproxy/envoy:latest` docker hub tag seemed to have gone away. Use the explicit version instead.