### PR TITLE
Only build subset of docker images for presubmit runs

### DIFF
--- a/kokoro/master.cfg
+++ b/kokoro/master.cfg
@@ -1,1 +1,5 @@
 build_file: "grpc-web/scripts/kokoro.sh"
+env_vars {
+  key: "MASTER"
+  value: "1"
+}


### PR DESCRIPTION
To cut down presubmit runs from 30m to ~~15m~~ 21m. 


Further work is to parallelize the interop tests stuff.