### PR TITLE
Trying to speed up tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ In order to protect both you and ourselves, you will need to sign the
 The basic build script should run to completion.
 
 ```sh
-$ ./scripts/kokoro.sh
+$ MASTER=1 ./scripts/kokoro.sh
 ```
 
 More details to come.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,19 @@ services:
     depends_on:
       - common
     image: grpcweb/prereqs
+  grpc-base:
+    build:
+      context: ./
+      dockerfile: ./net/grpc/gateway/docker/grpc_base/Dockerfile
+    depends_on:
+      - prereqs
+    image: grpcweb/grpc-base
   echo-server:
     build:
       context: ./
       dockerfile: ./net/grpc/gateway/docker/echo_server/Dockerfile
     depends_on:
-      - prereqs
+      - grpc-base
     image: grpcweb/echo-server
     ports:
       - "9090:9090"
@@ -53,7 +60,7 @@ services:
       context: ./
       dockerfile: ./net/grpc/gateway/docker/nginx/Dockerfile
     depends_on:
-      - prereqs
+      - grpc-base
     image: grpcweb/nginx
     ports:
       - "8080:8080"
@@ -73,7 +80,7 @@ services:
       context: ./
       dockerfile: ./net/grpc/gateway/docker/commonjs_client/Dockerfile
     depends_on:
-      - common
+      - prereqs
     image: grpcweb/commonjs-client
     ports:
       - "8081:8081"

--- a/net/grpc/gateway/docker/common/Dockerfile
+++ b/net/grpc/gateway/docker/common/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get -qq update && apt-get -qq install -y \
 
 WORKDIR /tmp
 
-RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/\
-protoc-3.8.0-linux-x86_64.zip -o protoc.zip && \
+RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/\
+protoc-3.11.4-linux-x86_64.zip -o protoc.zip && \
   unzip -qq protoc.zip && \
   cp ./bin/protoc /usr/local/bin/protoc
 

--- a/net/grpc/gateway/docker/commonjs_client/Dockerfile
+++ b/net/grpc/gateway/docker/commonjs_client/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpcweb/common
+FROM grpcweb/prereqs
 
 WORKDIR /github/grpc-web/net/grpc/gateway/examples/echo
 
@@ -23,6 +23,7 @@ RUN protoc -I=. echo.proto \
 WORKDIR /github/grpc-web/net/grpc/gateway/examples/echo/commonjs-example
 
 RUN npm install && \
+  npm link grpc-web && \
   npx webpack && \
   cp echotest.html /var/www/html && \
   cp dist/main.js /var/www/html/dist

--- a/net/grpc/gateway/docker/grpc_base/Dockerfile
+++ b/net/grpc/gateway/docker/grpc_base/Dockerfile
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpcweb/grpc-base
+FROM grpcweb/prereqs
 
 WORKDIR /github/grpc-web
 
-RUN make echo_server
+RUN cd third_party/grpc && \
+  make install
 
-WORKDIR /github/grpc-web/net/grpc/gateway/examples/echo
-
-EXPOSE 9090
-CMD ["./echo_server"]
+RUN cd third_party/grpc/third_party/protobuf && \
+  make install

--- a/net/grpc/gateway/docker/nginx/Dockerfile
+++ b/net/grpc/gateway/docker/nginx/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM grpcweb/prereqs
+FROM grpcweb/grpc-base
 
 RUN apt-get -qq install -y \
   zip

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -15,10 +15,11 @@
 FROM grpcweb/common
 
 ARG MAKEFLAGS=-j8
+ARG BUILDIFIER_VERSION=1.0.0
+ARG BAZEL_VERSION=2.2.0
+
 
 WORKDIR /github/grpc-web
-
-COPY . .
 
 RUN git checkout . && \
   git clean -f -d -x && \
@@ -26,15 +27,30 @@ RUN git checkout . && \
   git checkout third_party && \
   ./scripts/init_submodules.sh
 
+COPY ./javascript ./javascript
+COPY ./net ./net
+COPY ./packages ./packages
+COPY ./scripts ./scripts
+COPY ./test ./test
+
 RUN cd ./packages/grpc-web && \
   npm install && \
   npm run build && \
   npm link
 
-RUN cd ./third_party/grpc && \
-  make install
+RUN wget -O buildifier \
+  https://github.com/bazelbuild/buildtools/releases/download/$BUILDIFIER_VERSION/buildifier && \
+  chmod +x ./buildifier && \
+  ./buildifier --mode=check --lint=warn --warnings=all -r bazel javascript net && \
+  rm ./buildifier
 
-RUN cd ./third_party/grpc/third_party/protobuf && \
-  make install
+RUN wget -O bazel-installer.sh \
+  https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/\
+bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
+  chmod +x ./bazel-installer.sh && \
+  ./bazel-installer.sh && \
+  rm ./bazel-installer.sh
 
-RUN make install-plugin
+RUN bazel build javascript/net/grpc/web/... && \
+  cp $(bazel info bazel-genfiles)/javascript/net/grpc/web/protoc-gen-grpc-web \
+  /usr/local/bin/protoc-gen-grpc-web

--- a/scripts/docker-run-interop-tests.sh
+++ b/scripts/docker-run-interop-tests.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 set -ex
 
-# This script is intended to be run with the base image from
+# This script is intended to be run within the base image from
 # net/grpc/gateway/docker/prereqs/Dockerfile
 
 cd /github/grpc-web/test/interop && \

--- a/scripts/docker-run-tests.sh
+++ b/scripts/docker-run-tests.sh
@@ -14,6 +14,15 @@
 # limitations under the License.
 set -ex
 
+# This script is intended to be run within the base image from
+# net/grpc/gateway/docker/prereqs/Dockerfile
+
+cd /github/grpc-web && \
+  bazel clean && \
+  bazel test --cache_test_results=no \
+    //javascript/net/grpc/web/... \
+    //net/grpc/gateway/examples/...
+
 cd /github/grpc-web/packages/grpc-web && \
   npm run prepare && \
   npm test

--- a/scripts/run_basic_tests.sh
+++ b/scripts/run_basic_tests.sh
@@ -19,8 +19,6 @@ REPO_DIR=$(realpath "${SCRIPT_DIR}/..")
 
 # Set up
 cd "${REPO_DIR}"
-./scripts/init_submodules.sh
-make clean
 
 
 # These programs need to be already installed
@@ -30,41 +28,6 @@ do
   command -v "$p" > /dev/null 2>&1 || \
     { echo >&2 "$p is required but not installed. Aborting."; exit 1; }
 done
-
-
-# Lint bazel files.
-BUILDIFIER_VERSION=1.0.0
-BUILDIFIER_SUFFIX=""
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  BUILDIFIER_SUFFIX=".mac"
-fi
-wget -O buildifier "https://github.com/bazelbuild/buildtools/releases/download/${BUILDIFIER_VERSION}/buildifier${BUILDIFIER_SUFFIX}"
-chmod +x "./buildifier"
-./buildifier -version
-./buildifier --mode=check --lint=warn --warnings=all -r bazel javascript net
-rm ./buildifier
-
-# Run all bazel unit tests
-BAZEL_VERSION=2.2.0
-BAZEL_OS="linux"
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  BAZEL_OS="darwin"
-fi
-wget -O bazel-installer.sh https://github.com/bazelbuild/bazel/releases/download/"${BAZEL_VERSION}"/bazel-"${BAZEL_VERSION}"-installer-"${BAZEL_OS}"-x86_64.sh
-chmod +x ./bazel-installer.sh
-./bazel-installer.sh --user
-rm ./bazel-installer.sh
-$HOME/bin/bazel version
-$HOME/bin/bazel clean
-$HOME/bin/bazel test \
-  //javascript/net/grpc/web/... \
-  //net/grpc/gateway/examples/...
-
-
-# Build the grpc-web npm package
-cd packages/grpc-web && \
-  npm install && \
-  cd ../..
 
 
 # Build all relevant docker images. They should all build successfully.

--- a/scripts/run_interop_tests.sh
+++ b/scripts/run_interop_tests.sh
@@ -19,8 +19,6 @@ REPO_DIR=$(realpath "${SCRIPT_DIR}/..")
 
 # Set up
 cd "${REPO_DIR}"
-./scripts/init_submodules.sh
-make clean
 
 
 # These programs need to be already installed


### PR DESCRIPTION
Trying to speed up tests:
- for tests triggered by pull requests (i.e. basic tests and interop tests), if possible, avoid having to compile `grpc` and `protobuf` from scratch
- use `bazel` to compile the `protoc-gen-grpc-web` plugin instead of `make plugin`, seems much faster
- for `master` branch continuous integration testing (i.e. once every X hours), that can take as long as it needs

other changes:
- move `bazel` and `buildifier` tests into some docker image to minimize changes to the host's system, plus the benefit of being able to reuse `bazel`