### PR TITLE
Fix nginx build after internal absl change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PROTOC := $(PROTO_SRC)/protoc
 GRPC_INC := $(ROOT_DIR)/third_party/grpc/include
 GRPC_SRC := $(ROOT_DIR)/third_party/grpc
 GRPC_LIB := $(ROOT_DIR)/third_party/grpc/libs/opt
+ABSL_SRC := $(ROOT_DIR)/third_party/grpc/third_party/abseil-cpp
 
 all: clean package_static
 
@@ -30,16 +31,19 @@ protos:
 --cpp_out="$(ROOT_DIR)/google/rpc"
 
 NGINX_DIR := third_party/nginx
-NGINX_LD_OPT := -L"$(PROTO_LIB)" -L"$(GRPC_LIB)" -lgrpc++ \
--lgrpc -lprotobuf -lpthread -ldl -lrt -lstdc++ -lm
+NGINX_LD_OPT := -L"$(PROTO_LIB)" -L"$(GRPC_LIB)" \
+-lgrpc++ -lgrpc -lprotobuf \
+-labsl_str_format_internal -labsl_int128 \
+-lpthread -ldl -lrt -lstdc++ -lm
 ifeq ($(OS), Darwin)
 NGINX_LD_OPT := -L"$(PROTO_LIB)" -L"$(GRPC_LIB)" -lgrpc++ \
 -lgrpc -lprotobuf -lpthread -lstdc++ -lm
 endif
 
 NGINX_STATIC_LD_OPT := -L"$(PROTO_LIB)" -L"$(GRPC_LIB)" \
--l:libgrpc++.a -l:libgrpc.a -l:libprotobuf.a -lpthread -ldl \
--lrt -lstdc++ -lm
+-l:libgrpc++.a -l:libgrpc.a -l:libprotobuf.a \
+-labsl_str_format_internal -labsl_int128 \
+-lpthread -ldl -lrt -lstdc++ -lm
 ifeq ($(OS), Darwin)
 NGINX_STATIC_LD_OPT := $(NGINX_LD_OPT)
 endif
@@ -50,7 +54,7 @@ nginx_config:
 	--with-http_ssl_module \
 	--with-http_v2_module \
 	--with-cc-opt="-I /usr/local/include -I $(ROOT_DIR) -I $(PROTO_INC) -I $(PROTO_SRC) \
--I $(GRPC_INC) -I $(GRPC_SRC)" \
+-I $(GRPC_INC) -I $(GRPC_SRC) -I $(ABSL_SRC)" \
 	--with-ld-opt="$(NGINX_LD_OPT)" \
 	--with-openssl="$(ROOT_DIR)/third_party/openssl" \
 	--add-module="$(ROOT_DIR)/net/grpc/gateway/nginx"
@@ -61,7 +65,7 @@ nginx_config_static:
 	--with-http_ssl_module \
 	--with-http_v2_module \
 	--with-cc-opt="-I /usr/local/include -I $(ROOT_DIR) -I $(PROTO_INC) -I $(PROTO_SRC) \
--I $(GRPC_INC) -I $(GRPC_SRC)" \
+-I $(GRPC_INC) -I $(GRPC_SRC) -I $(ABSL_SRC)" \
 	--with-ld-opt="$(NGINX_STATIC_LD_OPT)" \
 	--add-module="$(ROOT_DIR)/net/grpc/gateway/nginx"
 

--- a/net/grpc/gateway/codec/grpc_web_encoder.cc
+++ b/net/grpc/gateway/codec/grpc_web_encoder.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "net/grpc/gateway/runtime/types.h"
+#include "third_party/absl/strings/str_format.h"
 #include "third_party/grpc/include/grpcpp/support/byte_buffer.h"
 #include "third_party/grpc/include/grpcpp/support/slice.h"
 
@@ -79,10 +80,10 @@ void GrpcWebEncoder::EncodeStatus(const grpc::Status& status,
 
   // Encodes GRPC status.
   size_t grpc_status_size =
-      snprintf(nullptr, 0, kGrpcStatus, status.error_code());
+      absl::SNPrintF(nullptr, 0, kGrpcStatus, status.error_code());
   grpc_slice grpc_status = grpc_slice_malloc(grpc_status_size + 1);
-  snprintf(reinterpret_cast<char*>(GPR_SLICE_START_PTR(grpc_status)),
-           grpc_status_size + 1, kGrpcStatus, status.error_code());
+  absl::SNPrintF(reinterpret_cast<char*>(GPR_SLICE_START_PTR(grpc_status)),
+                 grpc_status_size + 1, kGrpcStatus, status.error_code());
   GPR_SLICE_SET_LENGTH(grpc_status, grpc_status_size);
   buffer.push_back(Slice(grpc_status, Slice::STEAL_REF));
   length += grpc_status_size;
@@ -90,11 +91,10 @@ void GrpcWebEncoder::EncodeStatus(const grpc::Status& status,
   // Encodes GRPC message.
   if (!status.error_message().empty()) {
     size_t grpc_message_size =
-        snprintf(nullptr, 0, kGrpcMessage, status.error_message().c_str());
+        absl::SNPrintF(nullptr, 0, kGrpcMessage, status.error_message());
     grpc_slice grpc_message = grpc_slice_malloc(grpc_message_size + 1);
-    snprintf(reinterpret_cast<char*>(GPR_SLICE_START_PTR(grpc_message)),
-             grpc_message_size + 1, kGrpcMessage,
-             status.error_message().c_str());
+    absl::SNPrintF(reinterpret_cast<char*>(GPR_SLICE_START_PTR(grpc_message)),
+                   grpc_message_size + 1, kGrpcMessage, status.error_message());
     GPR_SLICE_SET_LENGTH(grpc_message, grpc_message_size);
     buffer.push_back(Slice(grpc_message, Slice::STEAL_REF));
     length += grpc_message_size;

--- a/net/grpc/gateway/docker/nginx/Dockerfile
+++ b/net/grpc/gateway/docker/nginx/Dockerfile
@@ -15,9 +15,19 @@
 FROM grpcweb/grpc-base
 
 RUN apt-get -qq install -y \
-  zip
+  cmake zip
 
 WORKDIR /github/grpc-web
+
+RUN cd third_party/grpc/third_party && \
+  ln -s ./abseil-cpp/absl absl
+
+RUN cd third_party/grpc/third_party/abseil-cpp && \
+  git remote update && \
+  git checkout df3ea78 -b 20200225.1 && \
+  cmake . && \
+  make && \
+  make install
 
 RUN cd ./net/grpc/gateway/examples/echo && \
   sed -i 's/localhost:9090/echo-server:9090/g' nginx.conf

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -27,6 +27,7 @@ RUN git checkout . && \
   git checkout third_party && \
   ./scripts/init_submodules.sh
 
+COPY ./Makefile ./Makefile
 COPY ./javascript ./javascript
 COPY ./net ./net
 COPY ./packages ./packages


### PR DESCRIPTION
This PR comes from an internal code sync. There was a sweeping change to use `absl::` library for certain string functions and in this particular case, touched some `snprintf` function in the `net/grpc/gateway/codec` directory. In order to keep the code in sync and identical (internal has a different build system), I have to fix how the custom nginx grpc-web gateway is built here in open source. This gateway is not being actively developed right now.