### PR TITLE
Experimental Feature: Add ES6 import style

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -1471,6 +1471,53 @@ void PrintMultipleFilesMode(const FileDescriptor* file, string file_name,
   printer2.Print("}); // goog.scope\n\n");
 }
 
+void PrintClosureES6Imports(
+    Printer* printer, const FileDescriptor* file, string package_dot) {
+  for (int i = 0; i < file->service_count(); ++i) {
+    const ServiceDescriptor* service = file->service(i);
+
+    string service_namespace = "proto." + package_dot + service->name();
+    printer->Print(
+        "import $service_name$Client_import from 'goog:$namespace$';\n",
+        "service_name", service->name(),
+        "namespace", service_namespace + "Client");
+    printer->Print(
+        "import $service_name$PromiseClient_import from 'goog:$namespace$';\n",
+        "service_name", service->name(),
+        "namespace", service_namespace + "PromiseClient");
+  }
+
+  printer->Print("\n\n\n");
+}
+
+void PrintGrpcWebClosureES6File(Printer* printer, const FileDescriptor* file) {
+  string package_dot = file->package().empty() ? "" : file->package() + ".";
+
+  printer->Print(
+      "// GENERATED CODE -- DO NOT EDIT!\n"
+      "\n"
+      "/**\n"
+      " * @fileoverview gRPC-Web generated client stub for '$file$'\n"
+      " */\n"
+      "\n"
+      "\n",
+      "file", file->name());
+
+  PrintClosureES6Imports(printer, file, package_dot);
+
+  for (int i = 0; i < file->service_count(); ++i) {
+    const ServiceDescriptor* service = file->service(i);
+
+    string service_namespace = "proto." + package_dot + service->name();
+    printer->Print(
+        "export const $name$Client = $name$Client_import;\n",
+        "name", service->name());
+    printer->Print(
+        "export const $name$PromiseClient = $name$PromiseClient_import;\n",
+        "name", service->name());
+  }
+}
+
 class GeneratorOptions {
  public:
   GeneratorOptions();
@@ -1485,6 +1532,7 @@ class GeneratorOptions {
   string mode() const { return mode_; }
   ImportStyle import_style() const { return import_style_; }
   bool generate_dts() const { return generate_dts_; }
+  bool generate_closure_es6() const { return generate_closure_es6_; }
   bool multiple_files() const { return multiple_files_; }
 
  private:
@@ -1492,6 +1540,7 @@ class GeneratorOptions {
   string mode_;
   ImportStyle import_style_;
   bool generate_dts_;
+  bool generate_closure_es6_;
   bool multiple_files_;
 };
 
@@ -1500,6 +1549,7 @@ GeneratorOptions::GeneratorOptions()
       mode_(""),
       import_style_(ImportStyle::CLOSURE),
       generate_dts_(false),
+      generate_closure_es6_(false),
       multiple_files_(false){}
 
 bool GeneratorOptions::ParseFromOptions(const string& parameter,
@@ -1519,6 +1569,9 @@ bool GeneratorOptions::ParseFromOptions(
     } else if ("import_style" == option.first) {
       if ("closure" == option.second) {
         import_style_ = ImportStyle::CLOSURE;
+      } else if ("experimental_closure_es6" == option.second) {
+        import_style_ = ImportStyle::CLOSURE;
+        generate_closure_es6_ = true;
       } else if ("commonjs" == option.second) {
         import_style_ = ImportStyle::COMMONJS;
       } else if ("commonjs+dts" == option.second) {
@@ -1747,6 +1800,16 @@ class GrpcCodeGenerator : public CodeGenerator {
       Printer grpcweb_dts_printer(grpcweb_dts_output.get(), '$');
 
       PrintGrpcWebDtsFile(&grpcweb_dts_printer, file);
+    }
+
+    if (generator_options.generate_closure_es6()) {
+      string es6_file_name = StripProto(file->name()) + ".pb.grpc-web.js";
+
+      std::unique_ptr<ZeroCopyOutputStream> es6_output(
+          context->Open(es6_file_name));
+      Printer es6_printer(es6_output.get(), '$');
+
+      PrintGrpcWebClosureES6File(&es6_printer, file);
     }
 
     return true;

--- a/net/grpc/gateway/examples/echo/BUILD.bazel
+++ b/net/grpc/gateway/examples/echo/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_binary")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//bazel:closure_grpc_web_library.bzl", "closure_grpc_web_library")
 
@@ -9,8 +10,21 @@ proto_library(
 )
 
 closure_grpc_web_library(
-    name = "echo",
+    name = "echo_es6",
+    import_style = "es6",
     deps = [
         ":echo_proto",
+    ],
+)
+
+# A (very simple) inegration test.
+closure_js_binary(
+    name = "echo_es6_bin",
+    entry_points = [
+        "goog:proto.grpc.gateway.testing.EchoServiceClient",
+        "/net/grpc/gateway/examples/echo/echo.pb.grpc-web.js",
+    ],
+    deps = [
+        ":echo_es6",
     ],
 )


### PR DESCRIPTION
This change adds a new `import_style` that emits ES6 modules.
For now, this only re-exports the symbols from `import_style=closure`.

In the future, this will no longer require emitting google modules
(`goog.provide`). If protobuf ever adds support for emitting ES6
modules, we will use them instead of the `goog.provided`'d versions
as well.

Note that the Bazel integration is currently broken because of a
limitation in `rules_closure`.