### PR TITLE
use explicit envoy release tag

### DIFF
--- a/net/grpc/gateway/examples/helloworld/README.md
+++ b/net/grpc/gateway/examples/helloworld/README.md
@@ -154,7 +154,7 @@ To run Envoy (for later), you will need a simple Dockerfile. Put this in a
 `envoy.Dockerfile`.
 
 ```dockerfile
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy:v1.14.1
 COPY ./envoy.yaml /etc/envoy/envoy.yaml
 CMD /usr/local/bin/envoy -c /etc/envoy/envoy.yaml
 ```

--- a/net/grpc/gateway/examples/helloworld/envoy.Dockerfile
+++ b/net/grpc/gateway/examples/helloworld/envoy.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy:v1.14.1
 
 COPY ./envoy.yaml /etc/envoy/envoy.yaml
 


### PR DESCRIPTION
fix tag `latest` not found
```
Error response from daemon: manifest for envoyproxy/envoy:latest not found: manifest unknown: manifest unknown
```