### PR TITLE
Fix issues with callbacks

### DIFF
--- a/javascript/net/grpc/web/clientreadablestream.js
+++ b/javascript/net/grpc/web/clientreadablestream.js
@@ -43,14 +43,25 @@ const ClientReadableStream = function() {};
 
 
 /**
- * Register a callback to handle I/O events.
+ * Register a callback to handle different stream events.
  *
  * @param {string} eventType The event type
- * @param {function(?)} callback The call back to handle the event with
+ * @param {function(?)} callback The callback to handle the event with
  * an optional input object
  * @return {!ClientReadableStream} this object
  */
 ClientReadableStream.prototype.on = goog.abstractMethod;
+
+
+
+/**
+ * Remove a particular callback.
+ *
+ * @param {string} eventType The event type
+ * @param {function(?)} callback The callback to remove
+ * @return {!ClientReadableStream} this object
+ */
+ClientReadableStream.prototype.removeListener = goog.abstractMethod;
 
 
 

--- a/packages/grpc-web/externs.js
+++ b/packages/grpc-web/externs.js
@@ -6,6 +6,7 @@ var module;
  */
 module.ClientReadableStream = function() {};
 module.ClientReadableStream.prototype.on = function(eventType, callback) {};
+module.ClientReadableStream.prototype.removeListener = function(eventType, callback) {};
 module.ClientReadableStream.prototype.cancel = function() {};
 
 module.GenericClient = function() {};

--- a/packages/grpc-web/test/generated_code_test.js
+++ b/packages/grpc-web/test/generated_code_test.js
@@ -27,6 +27,14 @@ const mockXmlHttpRequest = require('mock-xmlhttprequest');
 
 var MockXMLHttpRequest;
 
+function multiDone(done, count) {
+  return function() {
+    count -= 1;
+    if (count <= 0) {
+      done();
+    }
+  };
+}
 
 describe('protoc generated code', function() {
   const genCodePath = path.resolve(__dirname, './echo_pb.js');
@@ -195,6 +203,7 @@ describe('grpc-web generated code (commonjs+grpcwebtext)', function() {
   });
 
   it('should receive trailing metadata', function(done) {
+    done = multiDone(done, 2);
     execSync(genCodeCmd);
     const {EchoServiceClient} = require(genCodePath);
     const {EchoRequest} = require(protoGenCodePath);
@@ -206,12 +215,19 @@ describe('grpc-web generated code (commonjs+grpcwebtext)', function() {
         200, {'Content-Type': 'application/grpc-web-text'},
         // a single data frame with an 'aaa' message, followed by,
         // a trailer frame with content 'grpc-status: 0\d\ax-custom-1: ababab'
-        'AAAAAAUKA2FhYYAAAAAkZ3JwYy1zdGF0dXM6IDANCngtY3VzdG9tLTE6IGFiYWJhYg0K');
+        'AAAAAAUKA2FhYYAAAAAkZ3JwYy1zdGF0dXM6IDANCngtY3VzdG9tLTE6IGFiYWJhYg0K'
+      );
     };
-    var call = echoService.echo(request, {'custom-header-1':'value1'},
-                                function(err, response) {
-                                  assert.equal('aaa', response.getMessage());
-                                });
+    var call = echoService.echo(
+      request, {'custom-header-1':'value1'},
+      function(err, response) {
+        if (err) {
+          assert.fail('should not receive error');
+        }
+        assert(response);
+        assert.equal('aaa', response.getMessage());
+        done();
+    });
     call.on('status', function(status) {
       assert.equal('object', typeof status.metadata);
       assert.equal(false, 'grpc-status' in status.metadata);
@@ -233,12 +249,54 @@ describe('grpc-web generated code (commonjs+grpcwebtext)', function() {
                   // a trailer frame with content 'grpc-status:10'
                   'gAAAABBncnBjLXN0YXR1czoxMA0K');
     };
-    var call = echoService.echo(request, {'custom-header-1':'value1'},
-                                function(err, response) {
-                                  assert.equal(10, err.code);
-                                  done();
-                                });
+    var call = echoService.echo(
+      request, {'custom-header-1':'value1'},
+      function(err, response) {
+        if (response) {
+          assert.fail('should not have received response');
+        }
+        assert(err);
+        assert.equal(10, err.code);
+        done();
+    });
   });
+
+  it('should not receive response on non-ok status', function(done) {
+    done = multiDone(done, 2);
+    execSync(genCodeCmd);
+    const {EchoServiceClient} = require(genCodePath);
+    const {EchoRequest} = require(protoGenCodePath);
+    var echoService = new EchoServiceClient('MyHostname', null, null);
+    var request = new EchoRequest();
+    request.setMessage('aaa');
+    MockXMLHttpRequest.onSend = function(xhr) {
+      xhr.respond(
+        200, {'Content-Type': 'application/grpc-web-text'},
+        // a single data frame with an 'aaa' message, followed by,
+        // a trailer frame with content 'grpc-status: 2\d\ax-custom-1: ababab'
+        'AAAAAAUKA2FhYYAAAAAkZ3JwYy1zdGF0dXM6IDINCngtY3VzdG9tLTE6IGFiYWJhYg0K'
+      );
+    };
+    var call = echoService.echo(
+      request, {'custom-header-1':'value1'},
+      function(err, response) {
+        if (response) {
+          assert.fail('should not have received response with non-OK status');
+        } else {
+          assert.equal(2, err.code);
+        }
+        done();
+      });
+    call.on('status', function(status) {
+      assert.equal(2, status.code);
+      assert.equal('object', typeof status.metadata);
+      assert.equal(false, 'grpc-status' in status.metadata);
+      assert.equal(true, 'x-custom-1' in status.metadata);
+      assert.equal('ababab', status.metadata['x-custom-1']);
+      done();
+    });
+  });
+
 });
 
 describe('grpc-web generated code (closure+grpcwebtext)', function() {
@@ -262,7 +320,8 @@ describe('grpc-web generated code (closure+grpcwebtext)', function() {
       `--entry_point=goog:proto.grpc.gateway.testing.EchoAppClient`,
       `--dependency_mode=PRUNE`,
       `--js_output_file ./test/generated/compiled.js`,
-      `--output_wrapper="%output%module.exports = proto.grpc.gateway.testing;"`,
+      `--output_wrapper="%output%module.exports = `+
+      `proto.grpc.gateway.testing;"`,
     ]
   );
   const closureCmd = "google-closure-compiler " + closureArgs.join(' ');
@@ -331,6 +390,241 @@ describe('grpc-web generated code (closure+grpcwebtext)', function() {
   });
 });
 
+describe('grpc-web generated code: callbacks tests', function() {
+  const protoGenCodePath = path.resolve(__dirname, './echo_pb.js');
+  const genCodePath = path.resolve(__dirname, './echo_grpc_web_pb.js');
+
+  const genCodeCmd =
+    'protoc -I=./test/protos echo.proto ' +
+    '--js_out=import_style=commonjs:./test ' +
+    '--grpc-web_out=import_style=commonjs,mode=grpcwebtext:./test';
+
+  var echoService;
+  var request;
+
+  before(function() {
+    MockXMLHttpRequest = mockXmlHttpRequest.newMockXhr()
+    global.XMLHttpRequest = MockXMLHttpRequest;
+
+    execSync(genCodeCmd);
+    const {EchoServiceClient} = require(genCodePath);
+    const {EchoRequest} = require(protoGenCodePath);
+    echoService = new EchoServiceClient('MyHostname', null, null);
+    request = new EchoRequest();
+    request.setMessage('aaa');
+  });
+
+  after(function() {
+    if (fs.existsSync(protoGenCodePath)) {
+      fs.unlinkSync(protoGenCodePath);
+    }
+    if (fs.existsSync(genCodePath)) {
+      fs.unlinkSync(genCodePath);
+    }
+  });
+
+  it('should receive initial metadata callback', function(done) {
+    done = multiDone(done, 2);
+    MockXMLHttpRequest.onSend = function(xhr) {
+      xhr.respond(
+        200, {
+          'Content-Type': 'application/grpc-web-text',
+          'initial-header-1': 'value1',
+        },
+        // a single data frame with message 'aaa'
+        'AAAAAAUKA2FhYQ==');
+    };
+    var call = echoService.echo(
+      request, {},
+      function(err, response) {
+        if (err) {
+          assert.fail('should not have received error');
+        } else {
+          assert.equal('aaa', response.getMessage());
+        }
+        done();
+      }
+    );
+    call.on('metadata', (metadata) => {
+      assert('initial-header-1' in metadata);
+      assert.equal('value1', metadata['initial-header-1']);
+      done();
+    });
+  });
+
+  it('should receive error, on html error', function(done) {
+    MockXMLHttpRequest.onSend = function(xhr) {
+      xhr.respond(
+        400, {'Content-Type': 'application/grpc-web-text'});
+    };
+    var call = echoService.echo(
+      request, {},
+      function(err, response) {
+        if (response) {
+          assert.fail('should not have received response with non-OK status');
+        } else {
+          assert.equal(3, err.code); // http error 400 mapped to grpc error 3
+        }
+        done();
+      }
+    );
+    call.on('status', (status) => {
+      assert.fail('should not have received a status callback');
+    });
+  });
+
+  it('should receive error, on grpc error', function(done) {
+    done = multiDone(done, 2);
+    MockXMLHttpRequest.onSend = function(xhr) {
+      xhr.respond(
+        200, {'Content-Type': 'application/grpc-web-text'},
+        // a single data frame with an 'aaa' message, followed by,
+        // a trailer frame with content 'grpc-status: 2\d\ax-custom-1: ababab'
+        'AAAAAAUKA2FhYYAAAAAkZ3JwYy1zdGF0dXM6IDINCngtY3VzdG9tLTE6IGFiYWJhYg0K'
+      );
+    };
+    var call = echoService.echo(
+      request, {},
+      function(err, response) {
+        if (response) {
+          assert.fail('should not have received response with non-OK status');
+        } else {
+          assert.equal(2, err.code);
+          assert.equal(true, 'x-custom-1' in err.metadata);
+          assert.equal('ababab', err.metadata['x-custom-1']);
+        }
+        done();
+      }
+    );
+    // also should receive trailing status callback
+    call.on('status', (status) => {
+      // grpc-status should not be part of trailing metadata
+      assert.equal(false, 'grpc-status' in status.metadata);
+      assert.equal(true, 'x-custom-1' in status.metadata);
+      assert.equal('ababab', status.metadata['x-custom-1']);
+      done();
+    });
+  });
+
+  it('should receive error, on response header error', function(done) {
+    MockXMLHttpRequest.onSend = function(xhr) {
+      xhr.respond(
+        200, {
+          'Content-Type': 'application/grpc-web-text',
+          'grpc-status': 2,
+          'grpc-message': 'some error',
+      });
+    };
+    var call = echoService.echo(
+      request, {},
+      function(err, response) {
+        if (response) {
+          assert.fail('should not have received response with non-OK status');
+        } else {
+          assert.equal(2, err.code);
+          assert.equal('some error', err.message);
+        }
+        done();
+      }
+    );
+    call.on('status', (status) => {
+      assert.fail('should not receive a trailing status callback');
+    });
+  });
+
+  it('should receive status callback', function(done) {
+    done = multiDone(done, 2);
+    MockXMLHttpRequest.onSend = function(xhr) {
+      xhr.respond(
+        200, {'Content-Type': 'application/grpc-web-text'},
+        // a single data frame with an 'aaa' message, followed by,
+        // a trailer frame with content 'grpc-status: 0\d\ax-custom-1: ababab'
+        'AAAAAAUKA2FhYYAAAAAkZ3JwYy1zdGF0dXM6IDANCngtY3VzdG9tLTE6IGFiYWJhYg0K'
+      );
+    };
+    var call = echoService.echo(
+      request, {},
+      function(err, response) {
+        if (err) {
+          assert.fail('should not receive error');
+        }
+        assert(response);
+        assert.equal('aaa', response.getMessage());
+        done();
+      }
+    );
+    call.on('status', (status) => {
+      // grpc-status should not be part of trailing metadata
+      assert.equal(false, 'grpc-status' in status.metadata);
+      assert.equal(true, 'x-custom-1' in status.metadata);
+      assert.equal('ababab', status.metadata['x-custom-1']);
+      done();
+    });
+  });
+
+  it('should trigger all callbacks', function(done) {
+    done = multiDone(done, 3);
+    MockXMLHttpRequest.onSend = function(xhr) {
+      xhr.respond(
+        400, {'Content-Type': 'application/grpc-web-text'});
+    };
+    var call = echoService.echo(
+      request, {},
+      function(err, response) {
+        if (response) {
+          assert.fail('should not have received response with non-OK status');
+        } else {
+          assert.equal(3, err.code); // http error 400 mapped to grpc error 3
+        }
+        done();
+      }
+    );
+    call.on('status', (status) => {
+      assert.fail('should not have received a status callback');
+    });
+    call.on('error', (error) => {
+      assert.equal(3, error.code);
+      done();
+    });
+    call.on('error', (error) => {
+      assert.equal(3, error.code);
+      done();
+    });
+  });
+
+  it('should be able to remove callback', function(done) {
+    done = multiDone(done, 2);
+    MockXMLHttpRequest.onSend = function(xhr) {
+      xhr.respond(
+        400, {'Content-Type': 'application/grpc-web-text'});
+    };
+    var call = echoService.echo(
+      request, {},
+      function(err, response) {
+        if (response) {
+          assert.fail('should not have received response with non-OK status');
+        } else {
+          assert.equal(3, err.code); // http error 400 mapped to grpc error 3
+        }
+        done();
+      }
+    );
+    call.on('status', (status) => {
+      assert.fail('should not have received a status callback');
+    });
+    const callbackA = (error) => {
+      assert.equal(3, error.code);
+      done();
+    };
+    const callbackB = (error) => {
+      assert.fail('should not be called');
+    }
+    call.on('error', callbackA);
+    call.on('error', callbackB);
+    call.removeListener('error', callbackB);
+  });
+
+});
 
 describe('grpc-web generated code (commonjs+dts)', function() {
   const protoGenCodePath = path.resolve(__dirname, './echo_pb.js');


### PR DESCRIPTION
Fixes #632 
Fixes #292 

This fixes the issue where calling `.on(<event>, callback)` to set a callback should have _added_ the callback to listen to `<event>`, instead of _overriding_ the existing one. This PR also adds a `.removeListener(<event>, callback)` method to allow removing a callback.

Fixed #786 

This fixes the issue where, in unary calls, we should _not_ have sent the data/response back up, if the rpc ended with a non-OK grpc status. See the linked comment from #786 for more details.

This PR also added tests for all the above scenarios.