### PR TITLE
Refactor error handling in grpcwebclientbase

### DIFF
--- a/javascript/net/grpc/web/BUILD.bazel
+++ b/javascript/net/grpc/web/BUILD.bazel
@@ -121,6 +121,7 @@ closure_js_library(
     visibility = ["//visibility:public"],
     deps = [
         ":clientreadablestream",
+        ":error",
         ":generictransportinterface",
         ":grpcwebstreamparser",
         ":status",

--- a/net/grpc/gateway/examples/echo/commonjs-example/client.js
+++ b/net/grpc/gateway/examples/echo/commonjs-example/client.js
@@ -64,14 +64,6 @@ var echoApp = new EchoApp(
   {
     EchoRequest: EchoRequest,
     ServerStreamingEchoRequest: ServerStreamingEchoRequest
-  },
-  {
-    checkGrpcStatusCode: function(status) {
-      if (status.code != grpc.web.StatusCode.OK) {
-        EchoApp.addRightMessage('Error code: '+status.code+' "'+
-                                status.details+'"');
-      }
-    }
   }
 );
 

--- a/net/grpc/gateway/examples/echo/echoapp.js
+++ b/net/grpc/gateway/examples/echo/echoapp.js
@@ -21,12 +21,10 @@ const echoapp = {};
 /**
  * @param {Object} echoService
  * @param {Object} ctors
- * @param {Object} handlers
  */
-echoapp.EchoApp = function(echoService, ctors, handlers) {
+echoapp.EchoApp = function(echoService, ctors) {
   this.echoService = echoService;
   this.ctors = ctors;
-  this.handlers = handlers;
 };
 
 echoapp.EchoApp.INTERVAL = 500; // ms
@@ -64,7 +62,6 @@ echoapp.EchoApp.prototype.echo = function(msg) {
   echoapp.EchoApp.addLeftMessage(msg);
   var unaryRequest = new this.ctors.EchoRequest();
   unaryRequest.setMessage(msg);
-  var self = this;
   var call = this.echoService.echo(unaryRequest,
                                    {"custom-header-1": "value1"},
                                    function(err, response) {
@@ -78,7 +75,6 @@ echoapp.EchoApp.prototype.echo = function(msg) {
     }
   });
   call.on('status', function(status) {
-    self.handlers.checkGrpcStatusCode(status);
     if (status.metadata) {
       console.log("Received metadata");
       console.log(status.metadata);
@@ -118,12 +114,10 @@ echoapp.EchoApp.prototype.repeatEcho = function(msg, count) {
   var stream = this.echoService.serverStreamingEcho(
     streamRequest,
     {"custom-header-1": "value1"});
-  var self = this;
   stream.on('data', function(response) {
     echoapp.EchoApp.addRightMessage(response.getMessage());
   });
   stream.on('status', function(status) {
-    self.handlers.checkGrpcStatusCode(status);
     if (status.metadata) {
       console.log("Received metadata");
       console.log(status.metadata);

--- a/net/grpc/gateway/examples/echo/echotest.html
+++ b/net/grpc/gateway/examples/echo/echotest.html
@@ -32,13 +32,6 @@ const module = {};
    {
      EchoRequest: proto.grpc.gateway.testing.EchoRequest,
      ServerStreamingEchoRequest: proto.grpc.gateway.testing.ServerStreamingEchoRequest
-   },
-   {
-     checkGrpcStatusCode: function(status) {
-       if (status.code != grpc.web.StatusCode.OK) {
-         echoapp.EchoApp.addRightMessage('Error code: '+status.code+' "'+status.details+'"');
-       }
-     }
    }
  );
  echoApp.load();


### PR DESCRIPTION
More fixes on how various callbacks are being handled in GrpcWebClientBase.

1. #632: in the callback-based API, the return type of a unary call (i.e. `rpcCall()`) is currently a `ClientReadableStream`, where user can subscribe to various callbacks like `status`/`error`/`end`/`metadata` via the `.on()` API (i.e. `EventEmitter` interface). However, there is currently a discrepancy between grpc-web and grpc-node. In grpc-node, such a return value will not react to `.on('error')` because the error is already being returned by the main `(err, resp) => ...` calback. Currently in grpc-web, both the main `(err, resp) => ...` callback and the `.on('error')` callback will fire on a single error, which is confusing. This change attempts to align the behavior with grpc-node by modifying the return value of `rpcCall()` to be a specialized version of `ClientReadableStream` that will disable the `.on('data')` and `.on('error')` callbacks even if added.

2. In an ongoing effort to clean up how errors are handled / returned in the `GrpcWebClientReadableStream` base class, I am rerouting ALL errors to a `handleError_` function for now. This also aligns with how grpc-node handles these errors - in the streaming case, each error will trigger both an `.on('status')` callback and an `.on('error')` callback. So as a first effort, let's always call `handleError_` in this class. Coz currently, some errors trigger an `.on('status')`, some errors trigger an `.on('error')` and there's no reason for that discrepancy.

3. #466: Now with the above, we can easily fix issues like this #466. Everything should be an error being triaged by `handleError_()`.

4. Added a lot of tests.

Summary (for callback-based calls):

1. Unary calls

| scenario | main `(err, resp) => ...` callback | `.on('status')` callback | `.on('error')` callback |
| --- | :---: | :---: | :---: |
| proper response + grpc-status: OK | `resp` returned | &#10003; | &#10007; |
| proper response + grpc-status: non-OK | `err` returned | &#10003; | &#10007; |
| any other error scenario (network error, deadline exceeded, unimplemented, etc) | `err` returned | &#10003; | &#10007; |

2. Server streaming calls

| scenario | `.on('data')` callback | `.on('status')` callback | `.on('error')` callback |
| --- | :---: | :---: | :---: |
| proper response + grpc-status: OK | &#10003; | &#10003; | &#10007; |
| proper response + grpc-status: non-OK | &#10003; | &#10003; | &#10003; |
| any other error scenario (network error, deadline exceeded, unimplemented, etc) | &#10007; | &#10003; | &#10003; |
