### PR TITLE
Revert #738

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -724,8 +724,8 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Indent();
           printer->Print(
               vars,
-              "new URL('/$package_dot$$service_name$/$method_name$', "
-              "this.hostname_).toString(),\n"
+              "this.hostname_ +\n"
+              "  '/$package_dot$$service_name$/$method_name$',\n"
               "request,\n"
               "metadata || {},\n"
               "this.methodInfo$method_name$);\n");
@@ -764,8 +764,8 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Indent();
           printer->Print(
               vars,
-              "new URL('/$package_dot$$service_name$/$method_name$', "
-              "this.hostname_).toString(),\n"
+              "this.hostname_ +\n"
+              "  '/$package_dot$$service_name$/$method_name$',\n"
               "request,\n"
               "metadata || {},\n"
               "this.methodInfo$method_name$,\n"


### PR DESCRIPTION
Revert #738 because of [this](https://github.com/grpc/grpc-web/pull/738#issuecomment-648321512).

If we need to fix the original issue with trailing slash, we will need to fix it some other way.

This only affects `mode=typescript`.