### PR TITLE
Add removeListener and missing metadata event types

### DIFF
--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -36,10 +36,24 @@ declare module "grpc-web" {
         callback: (err: Error) => void): ClientReadableStream<Response>;
     on (type: "status",
         callback: (status: Status) => void): ClientReadableStream<Response>;
+    on (type: "metadata",
+        callback: (status: Metadata) => void): ClientReadableStream<Response>;
     on (type: "data",
         callback: (response: Response) => void): ClientReadableStream<Response>;
     on (type: "end",
         callback: () => void): ClientReadableStream<Response>;
+
+    removeListener (type: "error",
+                    callback: (err: Error) => void): void;
+    removeListener (type: "status",
+                    callback: (status: Status) => void): void;
+    removeListener (type: "metadata",
+                    callback: (status: Metadata) => void): void;
+    removeListener (type: "data",
+                    callback: (response: Response) => void): void;
+    removeListener (type: "end",
+                    callback: () => void): void;
+                    
     cancel (): void;
   }
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/grpc/grpc-web/issues/873
- Add types of `removeListener`, which was introduced in https://github.com/grpc/grpc-web/pull/847
- Add missing `on('metadata')` event types