### PR TITLE
Update package README to say that gRPC-Web is GA.

### DIFF
--- a/packages/grpc-web/README.md
+++ b/packages/grpc-web/README.md
@@ -4,8 +4,7 @@ gRPC-Web provides a Javascript library that lets browser clients access a gRPC
 service. You can find out much more about gRPC in its own
 [website](https://grpc.io).
 
-The current release is a Beta release, and we expect to announce
-General-Availability by Oct. 2018.
+gRPC-Web is now Generally Available, and considered stable enough for production use.
 
 gRPC-Web clients connect to gRPC services via a special gateway proxy: the
 current version of the library uses [Envoy](https://www.envoyproxy.io/) by


### PR DESCRIPTION
Follow-up to #339.

Alternatively, we could edit https://github.com/grpc/grpc-web/blob/master/packages/grpc-web/scripts/build.js to copy the `README` from the repository root?