### PR TITLE
Initialize the connection to grpc-service before 1st request arrives

### DIFF
--- a/src/connector/src/main/java/com/google/grpcweb/GrpcPortNumRelay.java
+++ b/src/connector/src/main/java/com/google/grpcweb/GrpcPortNumRelay.java
@@ -1,14 +1,8 @@
 package com.google.grpcweb;
 
 public class GrpcPortNumRelay {
-  private static int sGrpcPortNum = 0;
-
   public static void setGrpcPortNum(int i) {
-    // make sure this is set only once
-    if (sGrpcPortNum == 0) sGrpcPortNum = i;
-  }
-
-  static int getGrpcPortNum() {
-    return sGrpcPortNum;
+    // TODO This class & method names are wrong - involves more than just setting the portnum
+    GrpcWebGuiceModule.init(i);
   }
 }

--- a/src/connector/src/main/java/com/google/grpcweb/GrpcServiceConnectionManager.java
+++ b/src/connector/src/main/java/com/google/grpcweb/GrpcServiceConnectionManager.java
@@ -21,26 +21,27 @@ import io.grpc.Channel;
 import io.grpc.ClientInterceptors;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import java.lang.invoke.MethodHandles;
+import java.util.logging.Logger;
 
 /**
  * TODO: Manage the connection pool to talk to the grpc-service
  */
 @Singleton
 class GrpcServiceConnectionManager {
-  private final int mGrpcPortNum;
+  private static final Logger LOG =
+      Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
+  private final ManagedChannel mChannel;
 
   GrpcServiceConnectionManager(int grpcPortNum) {
-    mGrpcPortNum  = grpcPortNum;
-  }
-
-  private ManagedChannel getManagedChannel() {
     // TODO: Manage a connection pool.
-    return ManagedChannelBuilder.forAddress("localhost", mGrpcPortNum)
+    mChannel = ManagedChannelBuilder.forAddress("localhost", grpcPortNum)
         .usePlaintext()
         .build();
+    LOG.info("**** connection channel initiated");
   }
 
   Channel getChannelWithClientInterceptor(GrpcWebClientInterceptor interceptor) {
-    return ClientInterceptors.intercept(getManagedChannel(), interceptor);
+    return ClientInterceptors.intercept(mChannel, interceptor);
   }
 }

--- a/src/connector/src/main/java/com/google/grpcweb/GrpcWebGuiceModule.java
+++ b/src/connector/src/main/java/com/google/grpcweb/GrpcWebGuiceModule.java
@@ -16,11 +16,26 @@
 package com.google.grpcweb;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 
 class GrpcWebGuiceModule extends AbstractModule {
+  private static Injector sInjector;
+  private static int sGrpcPortNum;
+
+  // This method should be called only once.
+  static void init(int i) {
+    sGrpcPortNum = i;
+    sInjector = Guice.createInjector(new GrpcWebGuiceModule());
+  }
+
+  static Injector getInjector() {
+    return sInjector;
+  }
+
   @Override
   protected void configure() {
     bind(GrpcServiceConnectionManager.class)
-        .toInstance(new GrpcServiceConnectionManager(GrpcPortNumRelay.getGrpcPortNum()));
+        .toInstance(new GrpcServiceConnectionManager(sGrpcPortNum));
   }
 }

--- a/src/connector/src/main/java/com/google/grpcweb/GrpcWebTrafficServlet.java
+++ b/src/connector/src/main/java/com/google/grpcweb/GrpcWebTrafficServlet.java
@@ -15,8 +15,6 @@
  */
 package com.google.grpcweb;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -29,8 +27,7 @@ public class GrpcWebTrafficServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response) {
-    Injector injector = Guice.createInjector(new GrpcWebGuiceModule());
-    RequestHandler reqHandler = injector.getInstance(RequestHandler.class);
+    RequestHandler reqHandler = GrpcWebGuiceModule.getInjector().getInstance(RequestHandler.class);
     reqHandler.handle(request, response);
   }
 


### PR DESCRIPTION
This will make sure the first request has no latency associated with opening the connection to grpc-service.

Interop tests are flaky for this reason, most probably.