### PR TITLE
Update protoc plugin to support Proto3 optional

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,8 +11,32 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+    ],
+    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+)
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "efaf69303e01caccc2447064fc1832dfd23c0c130df0dc5fc98a13185bb7d1a7",
+    strip_prefix = "protobuf-678da4f76eb9168c9965afc2149944a66cd48546",
+    urls = [
+        "https://github.com/google/protobuf/archive/678da4f76eb9168c9965afc2149944a66cd48546.tar.gz",
+    ],
+)
+
+
 load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
 
 rules_closure_dependencies()
 
 rules_closure_toolchains()
+
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,11 +13,11 @@ http_archive(
 
 http_archive(
     name = "bazel_skylib",
+    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
         "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
     ],
-    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
 )
 
 http_archive(
@@ -29,14 +29,8 @@ http_archive(
     ],
 )
 
-
 load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
 
 rules_closure_dependencies()
 
 rules_closure_toolchains()
-
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()

--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -1598,6 +1598,11 @@ class GrpcCodeGenerator : public CodeGenerator {
   GrpcCodeGenerator() {}
   ~GrpcCodeGenerator() override {}
 
+  uint64_t GetSupportedFeatures() const override {
+    // Code generators must explicitly support proto3 optional.
+    return CodeGenerator::FEATURE_PROTO3_OPTIONAL;
+  }
+
   bool Generate(const FileDescriptor* file, const string& parameter,
                 GeneratorContext* context, string* error) const override {
     GeneratorOptions generator_options;

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -23,6 +23,7 @@ RUN echo "\nloglevel=error\n" >> $HOME/.npmrc
 WORKDIR /github/grpc-web
 
 COPY ./Makefile ./Makefile
+COPY ./WORKSPACE ./WORKSPACE
 COPY ./bazel ./bazel
 COPY ./javascript ./javascript
 COPY ./net ./net

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -41,7 +41,7 @@ RUN cd ./packages/grpc-web && \
 RUN wget -nv -O buildifier \
   https://github.com/bazelbuild/buildtools/releases/download/$BUILDIFIER_VERSION/buildifier && \
   chmod +x ./buildifier && \
-  ./buildifier --mode=check --lint=warn --warnings=all -r bazel javascript net && \
+  ./buildifier --mode=check --lint=warn --warnings=all -r ./WORKSPACE bazel javascript net && \
   rm ./buildifier
 
 RUN wget -nv -O bazel-installer.sh \

--- a/scripts/init_submodules.sh
+++ b/scripts/init_submodules.sh
@@ -18,5 +18,5 @@ cd "$(dirname "$0")"/..
 git submodule --quiet update --init
 cd third_party/closure-library && git checkout tags/v20200406 -f && cd ../..
 cd third_party/openssl && git checkout tags/OpenSSL_1_0_2h -f && cd ../..
-cd third_party/grpc && git checkout tags/v1.28.1 -f && \
+cd third_party/grpc && git checkout tags/v1.30.0 -f && \
   git submodule --quiet update --init && cd ../..


### PR DESCRIPTION
Proto3 introduced the `optional` syntax to support [field presence](https://github.com/protocolbuffers/protobuf/blob/v3.12.0/docs/field_presence.md) tracking in [release 3.12.0](https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.0). We need to add support in our `protoc-gen-grpc-web` protoc plugin.

See [this doc](https://github.com/protocolbuffers/protobuf/blob/master/docs/implementing_proto3_presence.md#signaling-that-your-code-generator-supports-proto3-optional) for more details. Basically we need to add a function `GetSupportedFeatures()` to our grpc protoc plugins to mark our compliance.

See similar work being done in the main grpc repo: https://github.com/grpc/grpc/pull/22998

This requires adding some bazel stuff to pin `@com_google_protobuf` to a higher version (i.e. at least `3.12.0` or above).