### PR TITLE
Add missing types definitions

### DIFF
--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -632,10 +632,10 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
         "client_: grpcWeb.AbstractClientBase;\n"
         "hostname_: string;\n"
         "credentials_: null | { [index: string]: string; };\n"
-        "options_: null | { [index: string]: string; };\n\n"
+        "options_: null | { [index: string]: any; };\n\n"
         "constructor (hostname: string,\n"
         "             credentials?: null | { [index: string]: string; },\n"
-        "             options?: null | { [index: string]: string; }) {\n");
+        "             options?: null | { [index: string]: any; }) {\n");
     printer->Indent();
     printer->Print("if (!options) options = {};\n");
     printer->Print("if (!credentials) credentials = {};\n");
@@ -765,7 +765,7 @@ void PrintGrpcWebDtsClientClass(Printer* printer, const FileDescriptor* file,
     printer->Print(
         "constructor (hostname: string,\n"
         "             credentials?: null | { [index: string]: string; },\n"
-        "             options?: null | { [index: string]: string; });\n\n");
+        "             options?: null | { [index: string]: any; });\n\n");
     for (int method_index = 0; method_index < service->method_count();
          ++method_index) {
       const MethodDescriptor* method = service->method(method_index);

--- a/net/grpc/gateway/examples/echo/ts-example/client.ts
+++ b/net/grpc/gateway/examples/echo/ts-example/client.ts
@@ -166,41 +166,7 @@ class EchoApp {
   }
 }
 
-class StreamResponseInterceptor implements grpcWeb.StreamInterceptor<any, any> {
-  intercept(
-    request: grpcWeb.Request<any, any>,
-    invoker: (request: grpcWeb.Request<any, any>) =>
-      grpcWeb.ClientReadableStream<any>) {
-    class InterceptedStream implements grpcWeb.ClientReadableStream<any> {
-      stream: grpcWeb.ClientReadableStream<any>;
-      constructor(stream: grpcWeb.ClientReadableStream<any>) {
-        this.stream = stream;
-      };
-      on(eventType: string, callback: any) {
-        if (eventType == 'data') {
-          const newCallback = (response: any) => {
-            response.setMessage('[Intcpt Resp1]'+response.getMessage());
-            callback(response);
-          };
-          this.stream.on(eventType, newCallback);
-        } else {
-          this.stream.on(eventType, callback);
-        }
-        return this;
-      };
-      removeListener(eventType: string, callback: any) {
-      }
-      cancel() {}
-    }
-    var reqMsg = request.getRequestMessage();
-    reqMsg.setMessage('[Intcpt Req1]'+reqMsg.getMessage());
-    return new InterceptedStream(invoker(request));
-  };
-}
-
-var opts = {'streamInterceptors' : [new StreamResponseInterceptor()]};
-
-const echoService = new EchoServiceClient('http://localhost:8080', null, opts);
+const echoService = new EchoServiceClient('http://localhost:8080', null, null);
 
 const echoApp = new EchoApp(echoService);
 echoApp.load();

--- a/net/grpc/gateway/examples/echo/ts-example/client.ts
+++ b/net/grpc/gateway/examples/echo/ts-example/client.ts
@@ -166,7 +166,41 @@ class EchoApp {
   }
 }
 
-const echoService = new EchoServiceClient('http://localhost:8080', null, null);
+class StreamResponseInterceptor implements grpcWeb.StreamInterceptor<any, any> {
+  intercept(
+    request: grpcWeb.Request<any, any>,
+    invoker: (request: grpcWeb.Request<any, any>) =>
+      grpcWeb.ClientReadableStream<any>) {
+    class InterceptedStream implements grpcWeb.ClientReadableStream<any> {
+      stream: grpcWeb.ClientReadableStream<any>;
+      constructor(stream: grpcWeb.ClientReadableStream<any>) {
+        this.stream = stream;
+      };
+      on(eventType: string, callback: any) {
+        if (eventType == 'data') {
+          const newCallback = (response: any) => {
+            response.setMessage('[Intcpt Resp1]'+response.getMessage());
+            callback(response);
+          };
+          this.stream.on(eventType, newCallback);
+        } else {
+          this.stream.on(eventType, callback);
+        }
+        return this;
+      };
+      removeListener(eventType: string, callback: any) {
+      }
+      cancel() {}
+    }
+    var reqMsg = request.getRequestMessage();
+    reqMsg.setMessage('[Intcpt Req1]'+reqMsg.getMessage());
+    return new InterceptedStream(invoker(request));
+  };
+}
+
+var opts = {'streamInterceptors' : [new StreamResponseInterceptor()]};
+
+const echoService = new EchoServiceClient('http://localhost:8080', null, opts);
 
 const echoApp = new EchoApp(echoService);
 echoApp.load();

--- a/packages/grpc-web/externs.js
+++ b/packages/grpc-web/externs.js
@@ -25,3 +25,9 @@ module.Request.prototype.getRequestMessage = function() {};
 module.Request.prototype.getMethodDescriptor = function() {};
 module.Request.prototype.getMetadata = function() {};
 module.Request.prototype.getCallOptions = function() {};
+
+module.UnaryResponse = function() {};
+module.UnaryResponse.prototype.getResponseMessage = function() {};
+module.UnaryResponse.prototype.getMetadata = function() {};
+module.UnaryResponse.prototype.getMethodDescriptor = function() {};
+module.UnaryResponse.prototype.getStatus = function() {};

--- a/packages/grpc-web/externs.js
+++ b/packages/grpc-web/externs.js
@@ -6,7 +6,8 @@ var module;
  */
 module.ClientReadableStream = function() {};
 module.ClientReadableStream.prototype.on = function(eventType, callback) {};
-module.ClientReadableStream.prototype.removeListener = function(eventType, callback) {};
+module.ClientReadableStream.prototype.removeListener =
+  function(eventType, callback) {};
 module.ClientReadableStream.prototype.cancel = function() {};
 
 module.GenericClient = function() {};

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -3,47 +3,50 @@ declare module "grpc-web" {
   export interface Metadata { [s: string]: string; }
 
   export namespace AbstractClientBase {
-    class MethodInfo<Request, Response> {
-      constructor (responseType: new () => Response,
-                   requestSerializeFn: (request: Request) => {},
-                   responseDeserializeFn: (bytes: Uint8Array) => Response);
+    class MethodInfo<REQ, RESP> {
+      constructor (responseType: new () => RESP,
+                   requestSerializeFn: (request: REQ) => {},
+                   responseDeserializeFn: (bytes: Uint8Array) => RESP);
     }
   }
 
   export class AbstractClientBase {
-    unaryCall<Request, Response> (method: string,
-             request: Request,
-             metadata: Metadata,
-             methodInfo: AbstractClientBase.MethodInfo<Request, Response>
-            ): Promise<Response>;
+    thenableCall<REQ, RESP> (
+      method: string,
+      request: REQ,
+      metadata: Metadata,
+      methodDescriptor: MethodDescriptor<REQ, RESP>
+    ): Promise<RESP>;
 
-    rpcCall<Request, Response> (method: string,
-             request: Request,
-             metadata: Metadata,
-             methodInfo: AbstractClientBase.MethodInfo<Request, Response>,
-             callback: (err: Error, response: Response) => void
-            ): ClientReadableStream<Response>;
+    rpcCall<REQ, RESP> (
+      method: string,
+      request: REQ,
+      metadata: Metadata,
+      methodDescriptor: MethodDescriptor<REQ, RESP>,
+      callback: (err: Error, response: RESP) => void
+    ): ClientReadableStream<RESP>;
 
-    serverStreaming<Request, Response> (method: string,
-                     request: Request,
-                     metadata: Metadata,
-                     methodInfo: AbstractClientBase.MethodInfo<Request, Response>
-                    ): ClientReadableStream<Response>;
+    serverStreaming<REQ, RESP> (
+      method: string,
+      request: REQ,
+      metadata: Metadata,
+      methodDescriptor: MethodDescriptor<REQ, RESP>
+    ): ClientReadableStream<RESP>;
   }
 
-  export class ClientReadableStream<Response> {
+  export class ClientReadableStream<RESP> {
     on (eventType: "error",
-        callback: (err: Error) => void): ClientReadableStream<Response>;
+        callback: (err: Error) => void): ClientReadableStream<RESP>;
     on (eventType: "status",
-        callback: (status: Status) => void): ClientReadableStream<Response>;
+        callback: (status: Status) => void): ClientReadableStream<RESP>;
     on (eventType: "metadata",
-        callback: (status: Metadata) => void): ClientReadableStream<Response>;
+        callback: (status: Metadata) => void): ClientReadableStream<RESP>;
     on (eventType: "data",
-        callback: (response: Response) => void): ClientReadableStream<Response>;
+        callback: (response: RESP) => void): ClientReadableStream<RESP>;
     on (eventType: "end",
-        callback: () => void): ClientReadableStream<Response>;
+        callback: () => void): ClientReadableStream<RESP>;
     on (eventType: string,
-        callback: any): ClientReadableStream<Response>;
+        callback: any): ClientReadableStream<RESP>;
 
     removeListener (eventType: "error",
                     callback: (err: Error) => void): void;
@@ -52,7 +55,7 @@ declare module "grpc-web" {
     removeListener (eventType: "metadata",
                     callback: (status: Metadata) => void): void;
     removeListener (eventType: "data",
-                    callback: (response: Response) => void): void;
+                    callback: (response: RESP) => void): void;
     removeListener (eventType: "end",
                     callback: () => void): void;
     removeListener (eventType: string,
@@ -61,45 +64,45 @@ declare module "grpc-web" {
     cancel (): void;
   }
 
-  export interface StreamInterceptor<Req, Resp> {
-    intercept(request: Request<Req, Resp>,
-              invoker: (request: Request<Req, Resp>) =>
-      ClientReadableStream<Resp>): ClientReadableStream<Resp>;
+  export interface StreamInterceptor<REQ, RESP> {
+    intercept(request: Request<REQ, RESP>,
+              invoker: (request: Request<REQ, RESP>) =>
+      ClientReadableStream<RESP>): ClientReadableStream<RESP>;
   }
 
-  export interface UnaryInterceptor<Req, Resp> {
-    intercept(request: Request<Req, Resp>,
-              invoker: (request: Request<Req, Resp>) =>
-      Promise<UnaryResponse<Req, Resp>>): Promise<UnaryResponse<Req, Resp>>;
+  export interface UnaryInterceptor<REQ, RESP> {
+    intercept(request: Request<REQ, RESP>,
+              invoker: (request: Request<REQ, RESP>) =>
+      Promise<UnaryResponse<REQ, RESP>>): Promise<UnaryResponse<REQ, RESP>>;
   }
 
   export class CallOptions {
     constructor(options: { [index: string]: any; });
   }
 
-  export class MethodDescriptor<Req, Resp> {
+  export class MethodDescriptor<REQ, RESP> {
     constructor(name: string,
                 methodType: any,
                 requestType: any,
                 responseType: any,
                 requestSerializeFn: any,
                 responseDeserializeFn: any);
-    createRequest(requestMessage: Req,
+    createRequest(requestMessage: REQ,
                   metadata: Metadata,
-                  callOptions: CallOptions): UnaryResponse<Req, Resp>;
+                  callOptions: CallOptions): UnaryResponse<REQ, RESP>;
   }
   
-  export class Request<Req, Resp> {
-    getRequestMessage(): Req;
-    getMethodDescriptor(): MethodDescriptor<Req, Resp>;
+  export class Request<REQ, RESP> {
+    getRequestMessage(): REQ;
+    getMethodDescriptor(): MethodDescriptor<REQ, RESP>;
     getMetadata(): Metadata;
     getCallOptions(): CallOptions;
   }
   
-  export class UnaryResponse<Req, Resp> {
-    getResponseMessage(): Resp;
+  export class UnaryResponse<REQ, RESP> {
+    getResponseMessage(): RESP;
     getMetadata(): Metadata;
-    getMethodDescriptor(): MethodDescriptor<Req, Resp>;
+    getMethodDescriptor(): MethodDescriptor<REQ, RESP>;
     getStatus(): Status;
   }
 

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -45,8 +45,6 @@ declare module "grpc-web" {
         callback: (response: RESP) => void): ClientReadableStream<RESP>;
     on (eventType: "end",
         callback: () => void): ClientReadableStream<RESP>;
-    on (eventType: string,
-        callback: any): ClientReadableStream<RESP>;
 
     removeListener (eventType: "error",
                     callback: (err: Error) => void): void;
@@ -58,8 +56,6 @@ declare module "grpc-web" {
                     callback: (response: RESP) => void): void;
     removeListener (eventType: "end",
                     callback: () => void): void;
-    removeListener (eventType: string,
-                    callback: any): void;
                     
     cancel (): void;
   }

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -66,7 +66,13 @@ declare module "grpc-web" {
               invoker: (request: Request<Req, Resp>) =>
       ClientReadableStream<Resp>): ClientReadableStream<Resp>;
   }
-  
+
+  export interface UnaryInterceptor<Req, Resp> {
+    intercept(request: Request<Req, Resp>,
+              invoker: (request: Request<Req, Resp>) =>
+      Promise<UnaryResponse<Req, Resp>>): Promise<UnaryResponse<Req, Resp>>;
+  }
+
   export class CallOptions {
     constructor(options: { [index: string]: any; });
   }

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -32,29 +32,69 @@ declare module "grpc-web" {
   }
 
   export class ClientReadableStream<Response> {
-    on (type: "error",
+    on (eventType: "error",
         callback: (err: Error) => void): ClientReadableStream<Response>;
-    on (type: "status",
+    on (eventType: "status",
         callback: (status: Status) => void): ClientReadableStream<Response>;
-    on (type: "metadata",
+    on (eventType: "metadata",
         callback: (status: Metadata) => void): ClientReadableStream<Response>;
-    on (type: "data",
+    on (eventType: "data",
         callback: (response: Response) => void): ClientReadableStream<Response>;
-    on (type: "end",
+    on (eventType: "end",
         callback: () => void): ClientReadableStream<Response>;
+    on (eventType: string,
+        callback: any): ClientReadableStream<Response>;
 
-    removeListener (type: "error",
+    removeListener (eventType: "error",
                     callback: (err: Error) => void): void;
-    removeListener (type: "status",
+    removeListener (eventType: "status",
                     callback: (status: Status) => void): void;
-    removeListener (type: "metadata",
+    removeListener (eventType: "metadata",
                     callback: (status: Metadata) => void): void;
-    removeListener (type: "data",
+    removeListener (eventType: "data",
                     callback: (response: Response) => void): void;
-    removeListener (type: "end",
+    removeListener (eventType: "end",
                     callback: () => void): void;
+    removeListener (eventType: string,
+                    callback: any): void;
                     
     cancel (): void;
+  }
+
+  export interface StreamInterceptor<Req, Resp> {
+    intercept(request: Request<Req, Resp>,
+              invoker: (request: Request<Req, Resp>) =>
+      ClientReadableStream<Resp>): ClientReadableStream<Resp>;
+  }
+  
+  export class CallOptions {
+    constructor(options: { [index: string]: any; });
+  }
+
+  export class MethodDescriptor<Req, Resp> {
+    constructor(name: string,
+                methodType: any,
+                requestType: any,
+                responseType: any,
+                requestSerializeFn: any,
+                responseDeserializeFn: any);
+    createRequest(requestMessage: Req,
+                  metadata: Metadata,
+                  callOptions: CallOptions): UnaryResponse<Req, Resp>;
+  }
+  
+  export class Request<Req, Resp> {
+    getRequestMessage(): Req;
+    getMethodDescriptor(): MethodDescriptor<Req, Resp>;
+    getMetadata(): Metadata;
+    getCallOptions(): CallOptions;
+  }
+  
+  export class UnaryResponse<Req, Resp> {
+    getResponseMessage(): Resp;
+    getMetadata(): Metadata;
+    getMethodDescriptor(): MethodDescriptor<Req, Resp>;
+    getStatus(): Status;
   }
 
   export interface GrpcWebClientBaseOptions {

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -17,12 +17,13 @@
   "typings": "index.d.ts",
   "scripts": {
     "build": "node scripts/build.js",
-    "prepare": "npm run build && require-self",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "test": "mocha --timeout 60000 \"./test/**/*_test.js\""
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/google-protobuf": "~3.7.0",
     "command-exists": "~1.2.8",
     "google-closure-compiler": "~20200224.0.0",
     "google-protobuf": "~3.12.0",
@@ -30,7 +31,6 @@
     "gulp-eval": "~1.0.0",
     "mocha": "~5.2.0",
     "mock-xmlhttprequest": "~2.0.0",
-    "require-self": "0.2.1",
     "typescript": "~3.8.0"
   }
 }

--- a/packages/grpc-web/scripts/build.js
+++ b/packages/grpc-web/scripts/build.js
@@ -43,7 +43,8 @@ const closureArgs = [].concat(
   ]
 );
 
-const closureCompilerBin = path.resolve(__dirname, "../node_modules/.bin/google-closure-compiler");
+const closureCompilerBin =
+  path.resolve(__dirname, "../node_modules/.bin/google-closure-compiler");
 const closureCommand = closureCompilerBin + " " + closureArgs.join(' ');
 
 console.log(closureCommand);

--- a/packages/grpc-web/scripts/build.js
+++ b/packages/grpc-web/scripts/build.js
@@ -16,6 +16,7 @@
  *
  */
 
+const fs = require("fs");
 const path = require("path");
 const {exec} = require("child_process");
 
@@ -50,3 +51,8 @@ let child = exec(closureCommand);
 
 child.stdout.pipe(process.stdout);
 child.stderr.pipe(process.stderr);
+
+fs.symlinkSync(path.resolve(__dirname, "../index.js"),
+               path.resolve(__dirname, "../node_modules/grpc-web.js"));
+fs.symlinkSync(path.resolve(__dirname, "../index.d.ts"),
+               path.resolve(__dirname, "../node_modules/grpc-web.d.ts"));

--- a/packages/grpc-web/scripts/build.js
+++ b/packages/grpc-web/scripts/build.js
@@ -52,7 +52,15 @@ let child = exec(closureCommand);
 child.stdout.pipe(process.stdout);
 child.stderr.pipe(process.stderr);
 
-fs.symlinkSync(path.resolve(__dirname, "../index.js"),
-               path.resolve(__dirname, "../node_modules/grpc-web.js"));
-fs.symlinkSync(path.resolve(__dirname, "../index.d.ts"),
-               path.resolve(__dirname, "../node_modules/grpc-web.d.ts"));
+function createSymlink(target, path) {
+  fs.symlink(target, path, (err) => {
+    if (err && err.code != 'EEXIST') {
+      throw err;
+    }
+  });
+}
+
+createSymlink(path.resolve(__dirname, "../index.js"),
+              path.resolve(__dirname, "../node_modules/grpc-web.js"));
+createSymlink(path.resolve(__dirname, "../index.d.ts"),
+              path.resolve(__dirname, "../node_modules/grpc-web.d.ts"));

--- a/packages/grpc-web/test/eval_test.js
+++ b/packages/grpc-web/test/eval_test.js
@@ -28,7 +28,8 @@ describe('grpc-web generated code eval test (commonjs+dts)', function() {
   const genCodeCmd =
     'protoc -I=./test/protos foo.proto models.proto ' +
     '--js_out=import_style=commonjs:./test/generated ' +
-    '--grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:./test/generated';
+    '--grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:' +
+    './test/generated';
 
   before(function() {
     ['protoc', 'protoc-gen-grpc-web'].map(prog => {
@@ -55,7 +56,8 @@ describe('grpc-web generated code eval test (commonjs+dts)', function() {
 
 
 describe('grpc-web generated code eval test (typescript)', function() {
-  const genTsCodePath = path.resolve(__dirname, './generated/FooServiceClientPb.ts');
+  const genTsCodePath = path.resolve(__dirname,
+                                     './generated/FooServiceClientPb.ts');
 
   const genCodeCmd =
     'protoc -I=./test/protos foo.proto models.proto ' +

--- a/packages/grpc-web/test/eval_test.js
+++ b/packages/grpc-web/test/eval_test.js
@@ -81,6 +81,6 @@ describe('grpc-web generated code eval test (typescript)', function() {
 
   it('should eval', function() {
     execSync(genCodeCmd);
-    execSync(`tsc ${genTsCodePath}`);
+    execSync(`tsc --strict ${genTsCodePath}`);
   });
 });

--- a/packages/grpc-web/test/generated_code_test.js
+++ b/packages/grpc-web/test/generated_code_test.js
@@ -764,7 +764,8 @@ describe('grpc-web generated code: callbacks tests', function() {
     });
   });
 
-  it('should receive error, on response header error (streaming)', function(done) {
+  it('should receive error, on response header error (streaming)',
+     function(done) {
     done = multiDone(done, 2);
     MockXMLHttpRequest.onSend = function(xhr) {
       xhr.respond(

--- a/packages/grpc-web/test/plugin_test.js
+++ b/packages/grpc-web/test/plugin_test.js
@@ -179,10 +179,6 @@ describe('grpc-web plugin test, proto with no package', function() {
     '--js_out=import_style=commonjs:./test/generated ' +
     '--grpc-web_out=import_style=commonjs,mode=grpcwebtext:./test/generated';
 
-  var request;
-  var myClient;
-  var myPromiseClient;
-
   before(function() {
     ['protoc', 'protoc-gen-grpc-web'].map(prog => {
       if (!commandExists(prog)) {
@@ -192,54 +188,41 @@ describe('grpc-web plugin test, proto with no package', function() {
 
     removeDirectory(path.resolve(__dirname, GENERATED_CODE_PATH));
     fs.mkdirSync(path.resolve(__dirname, GENERATED_CODE_PATH));
+    MockXMLHttpRequest = mockXmlHttpRequest.newMockXhr();
+    global.XMLHttpRequest = MockXMLHttpRequest;
 
     execSync(genCodeCmd);
     assert.equal(true, fs.existsSync(genCodePath1));
     assert.equal(true, fs.existsSync(genCodePath2));
-
-    const {HelloRequest} = require(genCodePath1);
-    request = new HelloRequest();
-
-    const {GreeterClient} = require(genCodePath2);
-    myClient = new GreeterClient("MyHostname", null, null);
-    assert.equal('function', typeof myClient.sayHello);
-
-    const {GreeterPromiseClient} = require(genCodePath2);
-    myPromiseClient = new GreeterPromiseClient("MyHostname", null, null);
-    assert.equal('function', typeof myPromiseClient.sayHello);
   });
 
-  beforeEach(function() {
-    removeDirectory(path.resolve(__dirname, GENERATED_CODE_PATH));
-    fs.mkdirSync(path.resolve(__dirname, GENERATED_CODE_PATH));
-    MockXMLHttpRequest = mockXmlHttpRequest.newMockXhr();
-    global.XMLHttpRequest = MockXMLHttpRequest;
-  });
-
-  afterEach(function() {
+  after(function() {
     removeDirectory(path.resolve(__dirname, GENERATED_CODE_PATH));
   });
 
   it('should import', function() {
+    const {HelloRequest} = require(genCodePath1);
+    var request = new HelloRequest();
+
     request.setName('abc');
     assert.equal('abc', request.getName());
   });
 
-  it('PromiseClient: should exist', function() {
-    var p = myPromiseClient.sayHello(request, {});
-    assert.equal('function', typeof p.then);
+  it('callback-based generated client: should exist', function() {
+    const {GreeterClient} = require(genCodePath2);
+    var myClient = new GreeterClient("MyHostname", null, null);
+
+    assert.equal('function', typeof myClient.sayHello);
   });
 
-  it('PromiseClient: response should resolve promise', function() {
-    MockXMLHttpRequest.onSend = function(xhr) {
-      xhr.respond(200, {'Content-Type': 'application/grpc-web-text'},
-                  // a single data frame with 'aaa' message, encoded
-                  'AAAAAAUKA2FhYQ==');
-    };
+  it('promise-based generated client: should exist', function() {
+    const {HelloRequest} = require(genCodePath1);
+    const {GreeterPromiseClient} = require(genCodePath2);
+    var myClient = new GreeterPromiseClient("MyHostname", null, null);
 
-    myPromiseClient.sayHello(request, {})
-                   .then((response) => {
-                     assert.equal('aaa', response.getMessage());
-                   });
+    assert.equal('function', typeof myClient.sayHello);
+
+    var p = myClient.sayHello(new HelloRequest(), {});
+    assert.equal('function', typeof p.then);
   });
 });

--- a/packages/grpc-web/test/protos/echo.proto
+++ b/packages/grpc-web/test/protos/echo.proto
@@ -18,10 +18,13 @@ package grpc.gateway.testing;
 
 message EchoRequest {
   string message = 1;
+  int32 value = 2;
 }
 
 message EchoResponse {
   string message = 1;
+  // to test Request and Response having a different shape
+  string value = 2;
 }
 
 message ServerStreamingEchoRequest {

--- a/packages/grpc-web/test/tsc-tests/client01.ts
+++ b/packages/grpc-web/test/tsc-tests/client01.ts
@@ -1,3 +1,20 @@
+/**
+ *
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 import * as grpcWeb from 'grpc-web';
 
 import {MessageOuter} from './generated/test01_pb';

--- a/packages/grpc-web/test/tsc-tests/client02.ts
+++ b/packages/grpc-web/test/tsc-tests/client02.ts
@@ -1,3 +1,20 @@
+/**
+ *
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 import * as grpcWeb from 'grpc-web';
 
 import {Integer} from './generated/test03_pb';

--- a/packages/grpc-web/test/tsc-tests/client03.ts
+++ b/packages/grpc-web/test/tsc-tests/client03.ts
@@ -40,8 +40,14 @@ class MyStreamInterceptor implements grpcWeb.StreamInterceptor<
             callback(response);
           };
           this.stream.on(eventType, newCallback);
-        } else {
-          this.stream.on(eventType, callback);
+        } else if (eventType == 'error') {
+          this.stream.on('error', callback);
+        } else if (eventType == 'metadata') {
+          this.stream.on('metadata', callback);
+        } else if (eventType == 'status') {
+          this.stream.on('status', callback);
+        } else if (eventType == 'end') {
+          this.stream.on('end', callback);
         }
         return this;
       };

--- a/packages/grpc-web/test/tsc-tests/client03.ts
+++ b/packages/grpc-web/test/tsc-tests/client03.ts
@@ -1,0 +1,62 @@
+/**
+ *
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import * as grpcWeb from 'grpc-web';
+
+import {EchoRequest, EchoResponse} from './generated/echo_pb';
+import {EchoServiceClient} from './generated/echo_grpc_web_pb';
+
+// The StreamInterceptor interface is for the callback-based client.
+class StreamResponseInterceptor implements grpcWeb.StreamInterceptor<
+  EchoRequest, EchoResponse> {
+  intercept(
+    request: grpcWeb.Request<EchoRequest, EchoResponse>,
+    invoker: (request: grpcWeb.Request<EchoRequest, EchoResponse>) =>
+      grpcWeb.ClientReadableStream<EchoResponse>) {
+    class InterceptedStream implements grpcWeb.ClientReadableStream<
+      EchoResponse> {
+      stream: grpcWeb.ClientReadableStream<EchoResponse>;
+      constructor(stream: grpcWeb.ClientReadableStream<EchoResponse>) {
+        this.stream = stream;
+      };
+      on(eventType: string, callback: any) {
+        if (eventType == 'data') {
+          const newCallback = (response: EchoResponse) => {
+            response.setMessage('[-in-]'+response.getMessage());
+            callback(response);
+          };
+          this.stream.on(eventType, newCallback);
+        } else {
+          this.stream.on(eventType, callback);
+        }
+        return this;
+      };
+      removeListener(eventType: string, callback: any) {
+      }
+      cancel() {}
+    }
+    var reqMsg = request.getRequestMessage();
+    reqMsg.setMessage('[-out-]'+reqMsg.getMessage());
+    return new InterceptedStream(invoker(request));
+  };
+}
+
+var opts = {'streamInterceptors' : [new StreamResponseInterceptor()]};
+
+const echoService = new EchoServiceClient('http://localhost:8080', null, opts);
+
+export {echoService, EchoRequest}

--- a/packages/grpc-web/test/tsc-tests/client03.ts
+++ b/packages/grpc-web/test/tsc-tests/client03.ts
@@ -21,7 +21,7 @@ import {EchoRequest, EchoResponse} from './generated/echo_pb';
 import {EchoServiceClient} from './generated/echo_grpc_web_pb';
 
 // The StreamInterceptor interface is for the callback-based client.
-class StreamResponseInterceptor implements grpcWeb.StreamInterceptor<
+class MyStreamInterceptor implements grpcWeb.StreamInterceptor<
   EchoRequest, EchoResponse> {
   intercept(
     request: grpcWeb.Request<EchoRequest, EchoResponse>,
@@ -55,7 +55,7 @@ class StreamResponseInterceptor implements grpcWeb.StreamInterceptor<
   };
 }
 
-var opts = {'streamInterceptors' : [new StreamResponseInterceptor()]};
+var opts = {'streamInterceptors' : [new MyStreamInterceptor()]};
 
 const echoService = new EchoServiceClient('http://localhost:8080', null, opts);
 

--- a/packages/grpc-web/test/tsc-tests/client04.ts
+++ b/packages/grpc-web/test/tsc-tests/client04.ts
@@ -39,6 +39,7 @@ class MyUnaryInterceptor implements grpcWeb.UnaryInterceptor<
 
 var opts = {'unaryInterceptors' : [new MyUnaryInterceptor()]};
 
-const echoService = new EchoServicePromiseClient('http://localhost:8080', null, opts);
+const echoService = new EchoServicePromiseClient('http://localhost:8080',
+                                                 null, opts);
 
 export {echoService, EchoRequest}

--- a/packages/grpc-web/test/tsc-tests/client04.ts
+++ b/packages/grpc-web/test/tsc-tests/client04.ts
@@ -1,0 +1,44 @@
+/**
+ *
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import * as grpcWeb from 'grpc-web';
+
+import {EchoRequest, EchoResponse} from './generated/echo_pb';
+import {EchoServicePromiseClient} from './generated/echo_grpc_web_pb';
+
+// The UnaryInterceptor interface is for the promise-based client.
+class MyUnaryInterceptor implements grpcWeb.UnaryInterceptor<
+  EchoRequest, EchoResponse> {
+    intercept(request: grpcWeb.Request<EchoRequest, EchoResponse>,
+              invoker: (request: grpcWeb.Request<EchoRequest, EchoResponse>) =>
+      Promise<grpcWeb.UnaryResponse<EchoRequest, EchoResponse>>) {
+      const reqMsg = request.getRequestMessage();
+      reqMsg.setMessage('[-out-]' + reqMsg.getMessage());
+      return invoker(request).then((response: grpcWeb.UnaryResponse<
+        EchoRequest, EchoResponse>) => {
+          const responseMsg = response.getResponseMessage();
+          responseMsg.setMessage('[-in-]' + responseMsg.getMessage());
+          return response;
+        });
+    }
+  }
+
+var opts = {'unaryInterceptors' : [new MyUnaryInterceptor()]};
+
+const echoService = new EchoServicePromiseClient('http://localhost:8080', null, opts);
+
+export {echoService, EchoRequest}

--- a/packages/grpc-web/test/tsc-tests/client05.ts
+++ b/packages/grpc-web/test/tsc-tests/client05.ts
@@ -1,0 +1,50 @@
+/**
+ *
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import * as grpcWeb from 'grpc-web';
+
+import {EchoRequest, EchoResponse,
+        ServerStreamingEchoRequest,
+        ServerStreamingEchoResponse} from './generated/echo_pb';
+import {EchoServiceClient} from './generated/echo_grpc_web_pb';
+
+const echoService = new EchoServiceClient('http://localhost:8080', null, null);
+
+let req = new EchoRequest();
+req.setMessage('aaa');
+
+// this test tries to make sure that these types are as accurate as possible
+
+let call1 : grpcWeb.ClientReadableStream<EchoResponse> =
+  echoService.echo(req, {}, (err: grpcWeb.Error,
+                             response: EchoResponse) => {
+                             });
+
+call1
+  .on('status', (status: grpcWeb.Status) => {
+  })
+  .on('metadata', (metadata: grpcWeb.Metadata) => {
+  });
+
+let call2 : grpcWeb.ClientReadableStream<ServerStreamingEchoResponse> =
+  echoService.serverStreamingEcho(new ServerStreamingEchoRequest(), {});
+
+call2
+  .on('data', (response: ServerStreamingEchoResponse) => {
+  })
+  .on('error', (error: grpcWeb.Error) => {
+  });

--- a/packages/grpc-web/test/tsc-tests/client06.ts
+++ b/packages/grpc-web/test/tsc-tests/client06.ts
@@ -1,0 +1,35 @@
+/**
+ *
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import * as grpcWeb from 'grpc-web';
+
+import {EchoRequest, EchoResponse} from './generated/echo_pb';
+import {EchoServicePromiseClient} from './generated/echo_grpc_web_pb';
+
+const echoService = new EchoServicePromiseClient(
+  'http://localhost:8080', null, null);
+
+let req = new EchoRequest();
+req.setMessage('aaa');
+
+// this test tries to make sure that these types are as accurate as possible
+
+let p1 : Promise<EchoResponse> = echoService.echo(req, {});
+
+// why does the .then() add this extra 'void' type to the returned Promise?
+let p2 : Promise<void | EchoResponse> = p1.then((response: EchoResponse) => {
+});

--- a/packages/grpc-web/test/tsc_test.js
+++ b/packages/grpc-web/test/tsc_test.js
@@ -46,6 +46,7 @@ function runTscCmd(tscCmd) {
   }
 }
 const outputDir = './test/tsc-tests/generated';
+const tscCompilerOptions = `--allowJs --strict --noImplicitReturns`
 
 describe('tsc test01: nested messages', function() {
   before(function() {
@@ -67,7 +68,7 @@ describe('tsc test01: nested messages', function() {
 
   it('tsc should run and export', function() {
     runTscCmd(`tsc client01.ts generated/test01_pb.d.ts generated/test01_pb.js \
-      --allowJs --strict --outDir ./dist`);
+      ${tscCompilerOptions} --outDir ./dist`);
 
     // check for the tsc output
     assertFileExists('./tsc-tests/dist/client01.js');
@@ -106,7 +107,7 @@ describe('tsc test02: simple rpc, messages in separate proto', function() {
     runTscCmd(`tsc client02.ts generated/Test02ServiceClientPb.ts \
       generated/test02_pb.d.ts generated/test02_pb.js \
       generated/test03_pb.d.ts generated/test03_pb.js \
-      --allowJs --strict --outDir ./dist`);
+      ${tscCompilerOptions} --outDir ./dist`);
 
     // check for the tsc output
     assertFileExists('./tsc-tests/dist/client02.js');
@@ -148,9 +149,10 @@ describe('tsc test03: streamInterceptor', function() {
   });
 
   it('tsc should run and export', function(done) {
-    runTscCmd(`tsc client03.ts generated/echo_pb.d.ts generated/echo_pb.js \
+    const tscCmd = `tsc client03.ts generated/echo_pb.d.ts generated/echo_pb.js \
       generated/echo_grpc_web_pb.d.ts generated/echo_grpc_web_pb.js \
-      --allowJs --strict --outDir ./dist`);
+      ${tscCompilerOptions} --outDir ./dist`;
+    runTscCmd(tscCmd);
 
     // check for the tsc output
     assertFileExists('./tsc-tests/dist/client03.js');
@@ -213,7 +215,7 @@ describe('tsc test04: unaryInterceptor', function() {
   it('tsc should run and export', function(done) {
     const tscCmd = `tsc client04.ts generated/echo_pb.d.ts generated/echo_pb.js \
       generated/echo_grpc_web_pb.d.ts generated/echo_grpc_web_pb.js \
-      --allowJs --strict --outDir ./dist`;
+      ${tscCompilerOptions} --outDir ./dist`;
     runTscCmd(tscCmd);
 
     // check for the tsc output
@@ -247,4 +249,76 @@ describe('tsc test04: unaryInterceptor', function() {
     });
   });
 
+});
+
+describe('tsc test05: callback-based client', function() {
+  before(function() {
+    cleanup();
+    createGeneratedCodeDir();
+    MockXMLHttpRequest = mockXmlHttpRequest.newMockXhr();
+    global.XMLHttpRequest = MockXMLHttpRequest;
+    const genCmd = `protoc -I=./test/protos echo.proto \
+      --js_out=import_style=commonjs:${outputDir} \
+      --grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:${outputDir}`;
+    execSync(genCmd);
+  });
+
+  after(function() {
+    cleanup();
+  });
+
+  it('generated code should exist', function() {
+    assertFileExists('./tsc-tests/generated/echo_pb.js');
+    assertFileExists('./tsc-tests/generated/echo_pb.d.ts');
+    assertFileExists('./tsc-tests/generated/echo_grpc_web_pb.js');
+    assertFileExists('./tsc-tests/generated/echo_grpc_web_pb.d.ts');
+  });
+
+  it('tsc should run and export', function() {
+    const tscCmd = `tsc client05.ts generated/echo_pb.d.ts generated/echo_pb.js \
+      generated/echo_grpc_web_pb.d.ts generated/echo_grpc_web_pb.js \
+      ${tscCompilerOptions} --outDir ./dist`;
+    // this test only makes sure the TS client code compiles successfully
+    runTscCmd(tscCmd);
+
+    // check for the tsc output
+    assertFileExists('./tsc-tests/dist/client05.js');
+    assertFileExists('./tsc-tests/dist/generated/echo_pb.js');
+  });
+});
+
+describe('tsc test06: promise-based client', function() {
+  before(function() {
+    cleanup();
+    createGeneratedCodeDir();
+    MockXMLHttpRequest = mockXmlHttpRequest.newMockXhr();
+    global.XMLHttpRequest = MockXMLHttpRequest;
+    const genCmd = `protoc -I=./test/protos echo.proto \
+      --js_out=import_style=commonjs:${outputDir} \
+      --grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:${outputDir}`;
+    execSync(genCmd);
+  });
+
+  after(function() {
+    cleanup();
+  });
+
+  it('generated code should exist', function() {
+    assertFileExists('./tsc-tests/generated/echo_pb.js');
+    assertFileExists('./tsc-tests/generated/echo_pb.d.ts');
+    assertFileExists('./tsc-tests/generated/echo_grpc_web_pb.js');
+    assertFileExists('./tsc-tests/generated/echo_grpc_web_pb.d.ts');
+  });
+
+  it('tsc should run and export', function() {
+    const tscCmd = `tsc client06.ts generated/echo_pb.d.ts generated/echo_pb.js \
+      generated/echo_grpc_web_pb.d.ts generated/echo_grpc_web_pb.js \
+      ${tscCompilerOptions} --outDir ./dist`;
+    // this test only makes sure the TS client code compiles successfully
+    runTscCmd(tscCmd);
+
+    // check for the tsc output
+    assertFileExists('./tsc-tests/dist/client06.js');
+    assertFileExists('./tsc-tests/dist/generated/echo_pb.js');
+  });
 });

--- a/packages/grpc-web/test/tsc_test.js
+++ b/packages/grpc-web/test/tsc_test.js
@@ -149,7 +149,8 @@ describe('tsc test03: streamInterceptor', function() {
   });
 
   it('tsc should run and export', function(done) {
-    const tscCmd = `tsc client03.ts generated/echo_pb.d.ts generated/echo_pb.js \
+    const tscCmd = `tsc client03.ts \
+      generated/echo_pb.d.ts generated/echo_pb.js \
       generated/echo_grpc_web_pb.d.ts generated/echo_grpc_web_pb.js \
       ${tscCompilerOptions} --outDir ./dist`;
     runTscCmd(tscCmd);
@@ -213,7 +214,8 @@ describe('tsc test04: unaryInterceptor', function() {
   });
 
   it('tsc should run and export', function(done) {
-    const tscCmd = `tsc client04.ts generated/echo_pb.d.ts generated/echo_pb.js \
+    const tscCmd = `tsc client04.ts \
+      generated/echo_pb.d.ts generated/echo_pb.js \
       generated/echo_grpc_web_pb.d.ts generated/echo_grpc_web_pb.js \
       ${tscCompilerOptions} --outDir ./dist`;
     runTscCmd(tscCmd);
@@ -275,7 +277,8 @@ describe('tsc test05: callback-based client', function() {
   });
 
   it('tsc should run and export', function() {
-    const tscCmd = `tsc client05.ts generated/echo_pb.d.ts generated/echo_pb.js \
+    const tscCmd = `tsc client05.ts \
+      generated/echo_pb.d.ts generated/echo_pb.js \
       generated/echo_grpc_web_pb.d.ts generated/echo_grpc_web_pb.js \
       ${tscCompilerOptions} --outDir ./dist`;
     // this test only makes sure the TS client code compiles successfully
@@ -311,7 +314,8 @@ describe('tsc test06: promise-based client', function() {
   });
 
   it('tsc should run and export', function() {
-    const tscCmd = `tsc client06.ts generated/echo_pb.d.ts generated/echo_pb.js \
+    const tscCmd = `tsc client06.ts \
+      generated/echo_pb.d.ts generated/echo_pb.js \
       generated/echo_grpc_web_pb.d.ts generated/echo_grpc_web_pb.js \
       ${tscCompilerOptions} --outDir ./dist`;
     // this test only makes sure the TS client code compiles successfully


### PR DESCRIPTION
Fixes #848: Fixed a bug where we can't pass the interceptors into the client constructor because of a type mismatch.

Fixes #868: Added `MethodDescriptor` to the exported types. Replace the deprecated `MethodInfo` with `MethodDescriptor`.

Fixes #877: Fixed issue where `UnaryResponse` symbols are being optimized away.

And in general added some missing classes to the exported types as well.

Added tests for both callback-based `StreamInterceptor` and promise-based `UnaryInterceptor`. And now execute `tsc` with `--strict`.

This is WIP.