### PR TITLE
Make mvn commands quieter

### DIFF
--- a/net/grpc/gateway/docker/java_interop_server/Dockerfile
+++ b/net/grpc/gateway/docker/java_interop_server/Dockerfile
@@ -34,9 +34,9 @@ WORKDIR /github/grpc-web
 
 RUN git clone https://github.com/grpc/grpc-web . && \
   cd src/connector && \
-  mvn install && \
+  mvn install --no-transfer-progress && \
   cd ../../net/grpc/gateway/examples/grpc-web-java/interop-test-service && \
-  mvn package 
+  mvn package --no-transfer-progress
 
 ENTRYPOINT ["java", "-cp", "net/grpc/gateway/examples/grpc-web-java/interop-test-service/target/interop-test-0.1-jar-with-dependencies.jar", "grpcweb.examples.StartServiceAndGrpcwebProxy"]
 


### PR DESCRIPTION
There's a lot of clutter like `Downloading from central ...` messages in the logs. Trying to see if this can make this quieter.

Example: https://g3c.corp.google.com/results/invocations/1fd59c18-6fdd-46d4-9f48-2c157e94751a/targets/grpc%2Fweb%2Finterop/log

Looks like `mvn --no-transfer-progress` is better than just `mvn -q`, which seems a bit _too_ quiet.