### PR TITLE
Pin @types/mocha back to fix master tests

### DIFF
--- a/net/grpc/gateway/docker/node_interop_server/Dockerfile
+++ b/net/grpc/gateway/docker/node_interop_server/Dockerfile
@@ -24,7 +24,7 @@ RUN cd packages/grpc-native-core && \
   npm link
 
 RUN cd packages/proto-loader && \
-  npm install @types/mocha && \
+  npm install @types/mocha@7.0.2&& \
   npm install --unsafe-perm
 
 WORKDIR /github/grpc-node/test


### PR DESCRIPTION
Fixes #893. The `8.0.0` release of `@types/mocha` seems to be breaking stuff.