### PR TITLE
Add error handling to a few error conditions

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -300,7 +300,14 @@ class GrpcWebClientBase {
 
     stream.on('end', function() {
       if (!errorEmitted) {
-        callback(null, responseReceived);
+        if (responseReceived == null) {
+          callback({
+            code: StatusCode.UNKNOWN,
+            message: 'Incomplete response',
+          });
+        } else {
+          callback(null, responseReceived);
+        }
       }
       if (useUnaryResponse) {
         callback(null, null);  // trigger unaryResponse


### PR DESCRIPTION
Fixes #881 

Added error handling on a few categories of errors:

1. Incomplete response - receive a valid beginning of a grpc-web frame (i.e. receive the frame length), but never receive the full rest of the frame.

2. Invalid protobuf payload - receive a valid and complete grpc-web frame, but the protobuf fails to deserialize properly.

3. Invalid grpc-web frame - receive an invalid grpc-web frame that fails to parse to the grpc-web wire format.