### PR TITLE
Add test to show how to access metadata in interceptor

### DIFF
--- a/packages/grpc-web/test/tsc-tests/client04.ts
+++ b/packages/grpc-web/test/tsc-tests/client04.ts
@@ -30,8 +30,19 @@ class MyUnaryInterceptor implements grpcWeb.UnaryInterceptor<
       reqMsg.setMessage('[-out-]' + reqMsg.getMessage());
       return invoker(request).then((response: grpcWeb.UnaryResponse<
         EchoRequest, EchoResponse>) => {
+          let result = '<-InitialMetadata->';
+          let initialMetadata = response.getMetadata();
+          for (let i in initialMetadata) {
+            result += i + ': ' + initialMetadata[i];
+          }
+          result += '<-TrailingMetadata->';
+          let trailingMetadata = response.getStatus().metadata;
+          for (let i in trailingMetadata) {
+            result += i + ': ' + trailingMetadata[i];
+          }
           const responseMsg = response.getResponseMessage();
-          responseMsg.setMessage('[-in-]' + responseMsg.getMessage());
+          result += '[-in-]' + responseMsg.getMessage();
+          responseMsg.setMessage(result);
           return response;
         });
     }


### PR DESCRIPTION
Fixes #908 
Fixes #909 

Add a test to show explicitly how to access both the initial metadata and the trailing metadata in the `UnaryInterceptor` for promise-based clients.

