### PR TITLE
guard against null getResponseText()

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -141,7 +141,8 @@ class GrpcWebClientReadableStream {
       contentType = contentType.toLowerCase();
 
       if (googString.startsWith(contentType, 'application/grpc-web-text')) {
-        var responseText = self.xhr_.getResponseText();
+        // Ensure responseText is not null
+        var responseText = self.xhr_.getResponseText() || "";
         var newPos = responseText.length - responseText.length % 4;
         var newData = responseText.substr(self.pos_, newPos - self.pos_);
         if (newData.length == 0) return;


### PR DESCRIPTION
Given the READY_STATE_CHANGE event can be trigged from for various reasons and be in a situation where the response is not yet written, this guards against a null value which is possible per the specification:

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseText
