### PR TITLE
Remove duplicate decodeURIComponent call

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -210,7 +210,7 @@ class GrpcWebClientReadableStream {
               }
               self.handleError_({
                 code: Number(grpcStatusCode),
-                message: decodeURIComponent(grpcStatusMessage),
+                message: grpcStatusMessage,
                 metadata: trailers,
               });
             }


### PR DESCRIPTION
Follow up on #915 

`decodeURIComponent` should now be called centrally in `handleError()`. So we shouldn't be calling that twice.