### PR TITLE
Refactor ClientUnaryCallImpl

### DIFF
--- a/javascript/net/grpc/web/BUILD.bazel
+++ b/javascript/net/grpc/web/BUILD.bazel
@@ -61,6 +61,17 @@ closure_js_library(
 )
 
 closure_js_library(
+    name = "clientunarycallimpl",
+    srcs = [
+        "clientunarycallimpl.js",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":clientreadablestream",
+    ],
+)
+
+closure_js_library(
     name = "error",
     srcs = [
         "error.js",
@@ -96,6 +107,7 @@ closure_js_library(
     deps = [
         ":abstractclientbase",
         ":clientreadablestream",
+        ":clientunarycallimpl",
         ":error",
         ":grpcwebclientreadablestream",
         ":interceptor",

--- a/javascript/net/grpc/web/clientunarycallimpl.js
+++ b/javascript/net/grpc/web/clientunarycallimpl.js
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview This class handles ClientReadableStream returned by unary
+ * calls.
+ */
+
+goog.module('grpc.web.ClientUnaryCallImpl');
+
+goog.module.declareLegacyNamespace();
+
+const ClientReadableStream = goog.require('grpc.web.ClientReadableStream');
+
+/**
+ * @implements {ClientReadableStream<RESPONSE>}
+ * @template RESPONSE
+ */
+class ClientUnaryCallImpl {
+  /**
+   * @param {!ClientReadableStream<RESPONSE>} stream
+   */
+  constructor(stream) {
+    this.stream = stream;
+  }
+
+  /**
+   * @override
+   */
+  on(eventType, callback) {
+    if (eventType == 'data' || eventType == 'error') {
+      // unary call responses and errors should be handled by the main
+      // (err, resp) => ... callback
+      return this;
+    }
+    return this.stream.on(eventType, callback);
+  }
+
+  /**
+   * @override
+   */
+  removeListener(eventType, callback) {
+    return this.stream.removeListener(eventType, callback);
+  }
+
+  /**
+   * @override
+   */
+  cancel() {
+    this.stream.cancel();
+  }
+}
+
+exports = ClientUnaryCallImpl;

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -30,6 +30,7 @@ goog.module.declareLegacyNamespace();
 
 const AbstractClientBase = goog.require('grpc.web.AbstractClientBase');
 const ClientReadableStream = goog.require('grpc.web.ClientReadableStream');
+const ClientUnaryCallImpl = goog.require('grpc.web.ClientUnaryCallImpl');
 const Error = goog.require('grpc.web.Error');
 const GrpcWebClientReadableStream = goog.require('grpc.web.GrpcWebClientReadableStream');
 const HttpCors = goog.require('goog.net.rpc.HttpCors');
@@ -95,45 +96,6 @@ class GrpcWebClientBase {
    * @export
    */
   rpcCall(method, requestMessage, metadata, methodDescriptor, callback) {
-    /**
-     * @implements {ClientReadableStream}
-     */
-    class ClientUnaryCallImpl {
-      /**
-       * @param {!ClientReadableStream<RESPONSE>} stream
-       * @template RESPONSE
-       */
-      constructor(stream) {
-        this.stream = stream;
-      }
-
-      /**
-       * @override
-       */
-      on(eventType, callback) {
-        if (eventType == 'data' || eventType == 'error') {
-          // unary call responses and errors should be handled by the main
-          // (err, resp) => ... callback
-          return this;
-        }
-        return this.stream.on(eventType, callback);
-      }
-
-      /**
-       * @override
-       */
-      removeListener(eventType, callback) {
-        return this.stream.removeListener(eventType, callback);
-      }
-
-      /**
-       * @override
-       */
-      cancel() {
-        this.stream.cancel();
-      }
-    }
-
     methodDescriptor = AbstractClientBase.ensureMethodDescriptor(
         method, requestMessage, MethodType.UNARY, methodDescriptor);
     var hostname = AbstractClientBase.getHostname(method, methodDescriptor);


### PR DESCRIPTION
Refactor `ClientUnaryCallImpl` class into its own file because we need to re-use this in an internal use case.

author:@Jennnnny