### PR TITLE
Update envoy.yaml

### DIFF
--- a/net/grpc/gateway/examples/helloworld/envoy.yaml
+++ b/net/grpc/gateway/examples/helloworld/envoy.yaml
@@ -27,7 +27,9 @@ static_resources:
                   max_grpc_timeout: 0s
               cors:
                 allow_origin_string_match:
-                - prefix: "*"
+                  - safe_regex:
+                     google_re2: {}
+                     regex: \*
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"


### PR DESCRIPTION
Changed deprecated option 'envoy.api.v2.route.CorsPolicy.allow_origin' to
```
                allow_origin_string_match:
                  - safe_regex:
                     google_re2: {}
                     regex: \*
```