### PR TITLE
Add withCredentials option to index.d.ts

### DIFF
--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -105,6 +105,7 @@ declare module "grpc-web" {
   export interface GrpcWebClientBaseOptions {
     format?: string;
     suppressCorsPreflight?: boolean;
+    withCredentials?: boolean;
   }
 
   export class GrpcWebClientBase extends AbstractClientBase {


### PR DESCRIPTION
Small (but important) piece of documentation. 

I'm guessing that most using grpc-web in production will want to set `useCredentials` to true and it's difficult to see that it's even an option without checking the source.

Would you accept a PR for an auth example? It would be super helpful.