### PR TITLE
Update and correct types

### DIFF
--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -106,10 +106,12 @@ declare module "grpc-web" {
     format?: string;
     suppressCorsPreflight?: boolean;
     withCredentials?: boolean;
+    unaryInterceptors?: UnaryInterceptor<unknown, unknown>[];
+    streamInterceptors?: StreamInterceptor<unknown, unknown>[];
   }
 
   export class GrpcWebClientBase extends AbstractClientBase {
-    constructor (options: GrpcWebClientBaseOptions);
+    constructor(options?: GrpcWebClientBaseOptions);
   }
 
   export interface Error {


### PR DESCRIPTION
* Add `unaryInterceptors` and `streamInterceptors` to `GrpcWebClientBaseOptions`.
* Make `GrpcWebClientBaseOptions` optional in the constructor of `GrpcWebClientBase`.