### PR TITLE
bump envoy to v1.17.0

### DIFF
--- a/net/grpc/gateway/docker/envoy/Dockerfile
+++ b/net/grpc/gateway/docker/envoy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM envoyproxy/envoy:v1.16.1
+FROM envoyproxy/envoy:v1.17.0
 
 COPY net/grpc/gateway/examples/echo/envoy.yaml /etc/envoy/envoy.yaml
 

--- a/net/grpc/gateway/examples/echo/envoy.yaml
+++ b/net/grpc/gateway/examples/echo/envoy.yaml
@@ -12,7 +12,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -24,7 +24,8 @@ static_resources:
               - match: { prefix: "/" }
                 route:
                   cluster: echo_service
-                  max_grpc_timeout: 0s
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
               cors:
                 allow_origin_string_match:
                 - prefix: "*"

--- a/net/grpc/gateway/examples/helloworld/README.md
+++ b/net/grpc/gateway/examples/helloworld/README.md
@@ -294,7 +294,7 @@ run the 3 processes all in the background.
 
  ```sh
  $ docker run -d -v "$(pwd)"/envoy.yaml:/etc/envoy/envoy.yaml:ro \
-     --network=host envoyproxy/envoy:v1.16.1
+     --network=host envoyproxy/envoy:v1.17.0
  ```
 
 > NOTE: As per [this issue](https://github.com/grpc/grpc-web/issues/436):
@@ -302,7 +302,7 @@ run the 3 processes all in the background.
 >
 > ```sh
 > $ docker run -d -v "$(pwd)"/envoy.yaml:/etc/envoy/envoy.yaml:ro \
->     -p 8080:8080 -p 9901:9901 envoyproxy/envoy:v1.16.1
+>     -p 8080:8080 -p 9901:9901 envoyproxy/envoy:v1.17.0
 >  ```
 
  3. Run the simple Web Server. This hosts the static file `index.html` and

--- a/net/grpc/gateway/examples/helloworld/envoy.yaml
+++ b/net/grpc/gateway/examples/helloworld/envoy.yaml
@@ -12,7 +12,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -24,7 +24,8 @@ static_resources:
               - match: { prefix: "/" }
                 route:
                   cluster: greeter_service
-                  max_grpc_timeout: 0s
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
               cors:
                 allow_origin_string_match:
                 - prefix: "*"

--- a/scripts/run_interop_tests.sh
+++ b/scripts/run_interop_tests.sh
@@ -42,7 +42,7 @@ docker-compose build common prereqs node-interop-server interop-client java-inte
 # Run interop tests
 pid1=$(docker run -d \
   -v "$(pwd)"/test/interop/envoy.yaml:/etc/envoy/envoy.yaml:ro \
-  --network=host envoyproxy/envoy:v1.16.1)
+  --network=host envoyproxy/envoy:v1.17.0)
 pid2=$(docker run -d --network=host grpcweb/node-interop-server)
 
 run_tests

--- a/test/interop/README.md
+++ b/test/interop/README.md
@@ -33,7 +33,7 @@ tests.
 
 ```sh
 $ docker run -d -v $(pwd)/test/interop/envoy.yaml:/etc/envoy/envoy.yaml:ro \
-  --network=host envoyproxy/envoy:v1.16.1
+  --network=host envoyproxy/envoy:v1.17.0
 ```
 
 

--- a/test/interop/envoy.yaml
+++ b/test/interop/envoy.yaml
@@ -12,7 +12,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -24,7 +24,8 @@ static_resources:
               - match: { prefix: "/" }
                 route:
                   cluster: interop_service
-                  max_grpc_timeout: 0s
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
               cors:
                 allow_origin_string_match:
                 - prefix: "*"


### PR DESCRIPTION
- changed envoy docker image references from `v1.16.1` to `v1.17.0`
- modified all envoy yaml configs with the following:
1. switched `HttpConnectionManager` from `v2` to `v3`
2. replaced deprecated `max_grpc_timeout` setting with `max_stream_duration.grpc_timeout_header_max`