### PR TITLE
Allow null response

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -227,10 +227,12 @@ class GrpcWebClientBase {
    * @param {boolean} useUnaryResponse
    */
   static setCallback_(stream, callback, useUnaryResponse) {
+    var isResponseReceived = false;
     var responseReceived = null;
     var errorEmitted = false;
 
     stream.on('data', function(response) {
+      isResponseReceived = true;
       responseReceived = response;
     });
 
@@ -264,7 +266,7 @@ class GrpcWebClientBase {
 
     stream.on('end', function() {
       if (!errorEmitted) {
-        if (responseReceived == null) {
+        if (!isResponseReceived) {
           callback({
             code: StatusCode.UNKNOWN,
             message: 'Incomplete response',


### PR DESCRIPTION
We're using a custom codec, where null or undefined responses can be represented, and we use that for void methods, similar to how protobuf uses `Empty`.

This change allows grpc-web to accept responses that decode to `null` or `undefined`.