### PR TITLE
Update references to internal targets to use workspace root

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,7 +44,7 @@ rules_closure_dependencies()
 
 rules_closure_toolchains()
 
-load("//bazel:repositories.bzl", "grpc_web_toolchains")
+load("@com_github_grpc_grpc_web//bazel:repositories.bzl", "grpc_web_toolchains")
 
 grpc_web_toolchains()
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -23,5 +23,5 @@ def grpc_web_toolchains():
     """An utility method to load all gRPC-Web toolchains."""
 
     native.register_toolchains(
-        "//bazel:closure_toolchain",
+        "@com_github_grpc_grpc_web//bazel:closure_toolchain",
     )


### PR DESCRIPTION
This solves issues when this project is used as an external dependency
in other workspaces. Previously Bazel would not be able to find these
resources.

This fixes #1015