### PR TITLE
Attempt to fix master build

### DIFF
--- a/net/grpc/gateway/docker/grpcwebproxy/Dockerfile
+++ b/net/grpc/gateway/docker/grpcwebproxy/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:alpine
+FROM golang:1.15-alpine3.13
 
 RUN apk add --no-cache curl git ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 
-ARG VERSION=0.12.0
+ARG VERSION=0.14.0
 
 WORKDIR /tmp
 


### PR DESCRIPTION
`master` build has been failing since Feb 16.

Pinning back to Go 1.15 will temporarily unblock this. Logged at issue here: https://github.com/improbable-eng/grpc-web/issues/910.