### PR TITLE
Clean up docker builds

### DIFF
--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -22,7 +22,6 @@ RUN echo "\nloglevel=error\n" >> $HOME/.npmrc
 
 WORKDIR /github/grpc-web
 
-COPY .gitmodules .gitmodules
 COPY ./Makefile ./Makefile
 COPY ./WORKSPACE ./WORKSPACE
 COPY ./bazel ./bazel
@@ -30,16 +29,8 @@ COPY ./javascript ./javascript
 COPY ./net ./net
 COPY ./packages ./packages
 COPY ./scripts ./scripts
+COPY ./src ./src
 COPY ./test ./test
-
-# This section can be removed later
-RUN rm -rf third_party/ && \
-  git add .gitmodules && \
-  git checkout third_party && \
-  git rm --cached third_party/grpc && \
-  git rm --cached third_party/nginx/src && \
-  git rm --cached third_party/openssl && \
-  (cd third_party && git submodule add https://github.com/protocolbuffers/protobuf)
 
 RUN ./scripts/init_submodules.sh
 


### PR DESCRIPTION
Now that #1060 is merged, we can clean up the base docker build because `third_party` is no longer in a mixed state.