### PR TITLE
Fix grpc-js dep version

### DIFF
--- a/net/grpc/gateway/examples/echo/node-server/package.json
+++ b/net/grpc/gateway/examples/echo/node-server/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "main": "server.js",
   "dependencies": {
-    "@grpc/grpc-js": "~1.0.5",
+    "@grpc/grpc-js": "~1.1.8",
     "@grpc/proto-loader": "~0.5.0",
     "async": "~1.5.2",
     "google-protobuf": "~3.14.0",

--- a/net/grpc/gateway/examples/helloworld/package.json
+++ b/net/grpc/gateway/examples/helloworld/package.json
@@ -4,7 +4,7 @@
   "description": "gRPC-Web simple example",
   "main": "server.js",
   "devDependencies": {
-    "@grpc/grpc-js": "~1.0.5",
+    "@grpc/grpc-js": "~1.1.8",
     "@grpc/proto-loader": "~0.5.4",
     "async": "~1.5.2",
     "google-protobuf": "~3.14.0",


### PR DESCRIPTION
Fix dependency-bot alert: https://github.com/grpc/grpc-web/security/dependabot/net/grpc/gateway/examples/echo/node-server/package.json/@grpc%2Fgrpc-js/open