### PR TITLE
Document stream cancel function

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ stream.on('status', function(status) {
 stream.on('end', function(end) {
   // stream end signal
 });
+
+// to close the stream
+stream.cancel()
 ```
 
 For an in-depth tutorial, see [this


### PR DESCRIPTION
Document `ClientReadableStream`'s cancel function

Fixes https://github.com/grpc/grpc-web/issues/839