### PR TITLE
Generate empty files in closure_grpc_web_library() bazel rules

### DIFF
--- a/bazel/private/rules/closure_grpc_web_library.bzl
+++ b/bazel/private/rules/closure_grpc_web_library.bzl
@@ -59,6 +59,7 @@ def _generate_closure_grpc_web_srcs(
 
     args.add_all(_proto_include_paths(transitive_sources.to_list()), format_each = "-I%s")
 
+    args.add("--grpc-web_opt", "allow_empty_files=True")
     args.add("--grpc-web_opt", "mode=" + mode)
     if "es6" == import_style:
         args.add("--grpc-web_opt", "import_style=experimental_closure_es6")
@@ -73,7 +74,6 @@ def _generate_closure_grpc_web_srcs(
         basename = src.basename[:-(len(src.extension) + 1)]
 
         js = actions.declare_file(basename + "_grpc_web_pb.js", sibling = src)
-        actions.write(output = js, content = "")
         files.append(js)
 
         _assert(
@@ -84,7 +84,6 @@ def _generate_closure_grpc_web_srcs(
 
         if "es6" == import_style:
             es6 = actions.declare_file(basename + ".pb.grpc-web.js", sibling = src)
-            actions.write(output = es6, content = "")
             es6_files.append(es6)
 
             _assert(root == es6.root.path, "ES6 file should have same root: '{}' != '{}'".format(root, es6.root.path))

--- a/bazel/private/rules/closure_grpc_web_library.bzl
+++ b/bazel/private/rules/closure_grpc_web_library.bzl
@@ -73,6 +73,7 @@ def _generate_closure_grpc_web_srcs(
         basename = src.basename[:-(len(src.extension) + 1)]
 
         js = actions.declare_file(basename + "_grpc_web_pb.js", sibling = src)
+        actions.write(output = js, content = "")
         files.append(js)
 
         _assert(
@@ -83,6 +84,7 @@ def _generate_closure_grpc_web_srcs(
 
         if "es6" == import_style:
             es6 = actions.declare_file(basename + ".pb.grpc-web.js", sibling = src)
+            actions.write(output = es6, content = "")
             es6_files.append(es6)
 
             _assert(root == es6.root.path, "ES6 file should have same root: '{}' != '{}'".format(root, es6.root.path))

--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -1525,6 +1525,7 @@ class GeneratorOptions {
   bool generate_dts() const { return generate_dts_; }
   bool generate_closure_es6() const { return generate_closure_es6_; }
   bool multiple_files() const { return multiple_files_; }
+  bool allow_empty_files() const { return allow_empty_files_; }
   bool goog_promise() const { return goog_promise_; }
 
  private:
@@ -1535,6 +1536,7 @@ class GeneratorOptions {
   bool generate_dts_;
   bool generate_closure_es6_;
   bool multiple_files_;
+  bool allow_empty_files_;
   bool goog_promise_;
 };
 
@@ -1546,6 +1548,7 @@ GeneratorOptions::GeneratorOptions()
       generate_dts_(false),
       generate_closure_es6_(false),
       multiple_files_(false),
+      allow_empty_files_(false),
       goog_promise_(false) {}
 
 bool GeneratorOptions::ParseFromOptions(const string& parameter,
@@ -1582,6 +1585,8 @@ bool GeneratorOptions::ParseFromOptions(
       }
     } else if ("multiple_files" == option.first) {
       multiple_files_ = "True" == option.second;
+    } else if ("allow_empty_files" == option.first) {
+      allow_empty_files_ = "True" == option.second;
     } else if ("plugins" == option.first) {
       plugins_ = option.second;
     } else if ("goog_promise" == option.first) {
@@ -1666,7 +1671,7 @@ class GrpcCodeGenerator : public CodeGenerator {
       PrintProtoDtsFile(&proto_dts_printer, file);
     }
 
-    if (!file->service_count()) {
+    if (!generator_options.allow_empty_files() && !file->service_count()) {
       // No services, nothing to do.
       return true;
     }


### PR DESCRIPTION
This adds a flag `allow_empty_files` which forces the generation of output `.grpc.js` files even if they do not contain service definitions.  The flag is `False` by default, to retain the current behavior.  It is set `True` in the bazel plugin, and should be set when using any build system that tracks generated output files.

This prevents an issue if the source targets do not yield a `.grpc.js` generated file because they do not contain an `rpc` definition (e.g. proto files that only contain a `message`).

Resolves: #1076
Supersedes: #1077 