### PR TITLE
Bump Bazel version -> 4.1.0 and Protobuf version -> 3.17.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,10 +22,10 @@ http_archive(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "efaf69303e01caccc2447064fc1832dfd23c0c130df0dc5fc98a13185bb7d1a7",
-    strip_prefix = "protobuf-678da4f76eb9168c9965afc2149944a66cd48546",
+    sha256 = "77ad26d3f65222fd96ccc18b055632b0bfedf295cb748b712a98ba1ac0b704b2",
+    strip_prefix = "protobuf-3.17.3",
     urls = [
-        "https://github.com/google/protobuf/archive/678da4f76eb9168c9965afc2149944a66cd48546.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-all-3.17.3.tar.gz",
     ],
 )
 

--- a/net/grpc/gateway/docker/common/Dockerfile
+++ b/net/grpc/gateway/docker/common/Dockerfile
@@ -14,13 +14,15 @@
 
 FROM node:12-stretch
 
+ARG PROTOBUF_VERSION=3.17.3
+
 RUN apt-get -qq update && apt-get -qq install -y \
   unzip
 
 WORKDIR /tmp
 
-RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/\
-protoc-3.15.6-linux-x86_64.zip -o protoc.zip && \
+RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VERSION/\
+protoc-$PROTOBUF_VERSION-linux-x86_64.zip -o protoc.zip && \
   unzip -qq protoc.zip && \
   cp ./bin/protoc /usr/local/bin/protoc
 

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -16,7 +16,7 @@ FROM grpcweb/common
 
 ARG MAKEFLAGS=-j8
 ARG BUILDIFIER_VERSION=1.0.0
-ARG BAZEL_VERSION=3.7.0
+ARG BAZEL_VERSION=4.1.0
 
 RUN echo "\nloglevel=error\n" >> $HOME/.npmrc
 


### PR DESCRIPTION
Bazel -> 4.1.0 (Reducing memory-related crash on Mac)
---

Similar Bazel crashes to what's reported [here (github)](https://github.com/tensorflow/models/issues/3647) or [here (stackoverflow)](https://stackoverflow.com/questions/65605663/cannot-build-with-error-server-terminated-abruptly) was seen while building the `prereqs` image on macOS/Docker (16-inch intel mbp):

```
$ docker-compose build --no-cache common prereqs

...

Server terminated abruptly (error code: 14, error message: 'Socket closed', log file: '/root/.cache/bazel/_bazel_root/.../server/jvm.out')

------

failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c bazel build javascript/net/grpc/web/... &&   cp $(bazel info bazel-genfiles)/javascript/net/grpc/web/protoc-gen-grpc-web   /usr/local/bin/protoc-gen-grpc-web]: exit code: 37
```

The reason is that Bazel will crash under memory pressure. And bumping Bazel version to 4.1.0 fixes it on my Macbook (2019 16-inch mbp) for default Docker on Macsetup (uses 2GB memory).

Although, `./scripts/run_basic_tests.sh` would still crash with the same error, which is only fixable after bumping the runtime memory option (e.g. to 4GB) in Docker for Mac [settings ](https://docs.docker.com/docker-for-mac/#resources).

(Also big thanks @stanley-cheung for helping with the debugging :))

Protobuf
---

Updating Protobuf too because Bazel 4.0+ demands Protobuf 3.13+ (see https://github.com/bazelbuild/bazel/issues/12887#issuecomment-765950727).

