### PR TITLE
Require assert in hello world README example

### DIFF
--- a/net/grpc/gateway/examples/helloworld/README.md
+++ b/net/grpc/gateway/examples/helloworld/README.md
@@ -45,6 +45,7 @@ a nice response and send it back to the client via `callback(null, response)`.
 ```js
 var PROTO_PATH = __dirname + '/helloworld.proto';
 
+var assert = require('assert');
 var grpc = require('@grpc/grpc-js');
 var protoLoader = require('@grpc/proto-loader');
 var packageDefinition = protoLoader.loadSync(


### PR DESCRIPTION
This is needed to make the example work, in the example code https://github.com/grpc/grpc-web/blob/master/net/grpc/gateway/examples/helloworld/server.js the line is already included.