### PR TITLE
Replace use of `third_party/closure-library` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "third_party/closure-library"]
-	path = third_party/closure-library
-	url = https://github.com/google/closure-library.git
 [submodule "third_party/protobuf"]
 	path = third_party/protobuf
 	url = https://github.com/protocolbuffers/protobuf.git

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,6 @@ plugin:
 install-plugin:
 	cd "$(ROOT_DIR)"/javascript/net/grpc/web && make install
 
-client:
-	cd "$(ROOT_DIR)"/net/grpc/gateway/examples/echo && make client
-
-install-example:
-	cd "$(ROOT_DIR)"/net/grpc/gateway/examples/echo && make install
-
 clean:
-	cd "$(ROOT_DIR)"/net/grpc/gateway/examples/echo && make clean
 	cd "$(ROOT_DIR)"/javascript/net/grpc/web && make clean
 	cd "$(ROOT_DIR)"

--- a/net/grpc/gateway/docker/closure_client/Dockerfile
+++ b/net/grpc/gateway/docker/closure_client/Dockerfile
@@ -14,18 +14,11 @@
 
 FROM grpcweb/prereqs
 
-RUN apt-get -qq update && apt-get -qq install -y \
-  default-jdk
+WORKDIR /github/grpc-web/net/grpc/gateway/examples/echo
 
-WORKDIR /github/grpc-web
+RUN npm install
 
-RUN curl -sS https://dl.google.com/closure-compiler/compiler-20190909.zip \
-  -o compiler-latest.zip
-
-RUN rm -f closure-compiler.jar && \
-  unzip -p -qq -o compiler-latest.zip *.jar > closure-compiler.jar
-
-RUN make client && make install-example
+RUN make client && make install
 
 WORKDIR /var/www/html
 

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -26,19 +26,19 @@ WORKDIR /github/grpc-web
 COPY ./scripts ./scripts
 RUN ./scripts/init_submodules.sh
 
+COPY ./packages ./packages
+RUN cd ./packages/grpc-web && \
+  npm install && \
+  npm run build && \
+  npm link
+
 COPY ./Makefile ./Makefile
 COPY ./WORKSPACE ./WORKSPACE
 COPY ./bazel ./bazel
 COPY ./javascript ./javascript
 COPY ./net ./net
-COPY ./packages ./packages
 COPY ./src ./src
 COPY ./test ./test
-
-RUN cd ./packages/grpc-web && \
-  npm install && \
-  npm run build && \
-  npm link
 
 RUN wget -nv -O buildifier \
   https://github.com/bazelbuild/buildtools/releases/download/$BUILDIFIER_VERSION/buildifier && \

--- a/net/grpc/gateway/examples/echo/.gitignore
+++ b/net/grpc/gateway/examples/echo/.gitignore
@@ -1,0 +1,2 @@
+/package-lock.json
+/node_modules

--- a/net/grpc/gateway/examples/echo/Makefile
+++ b/net/grpc/gateway/examples/echo/Makefile
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 ROOT_DIR = ../../../../..
+NPM_DIR = ./node_modules
 PROTOC = protoc
 PROTOS_PATH = ../..
-EXAMPLES_PATH = net/grpc/gateway/examples/echo
 HTML_DIR = /var/www/html
 JS_IMPORT_STYLE = import_style=closure,binary
 JS_PATH = javascript/net/grpc/web
@@ -36,12 +36,12 @@ compiled-js:
 	rm $(ROOT_DIR)/$(PROTOBUF_PATH)/js/compatibility_tests/v3.0.0/commonjs/*_test.js || true
 	rm $(ROOT_DIR)/$(PROTOBUF_PATH)/js/compatibility_tests/v3.1.0/*_test.js || true
 	rm $(ROOT_DIR)/$(PROTOBUF_PATH)/js/compatibility_tests/v3.1.0/binary/*_test.js || true
-	java \
-  -jar $(ROOT_DIR)/closure-compiler.jar \
-  --js $(ROOT_DIR)/javascript \
-  --js $(ROOT_DIR)/net \
-  --js $(ROOT_DIR)/third_party/closure-library \
-  --js $(ROOT_DIR)/$(PROTOBUF_PATH)/js \
+	./node_modules/.bin/google-closure-compiler \
+  --js=*.js \
+  --js=$(OUT_DIR)/*.js \
+  --js=$(ROOT_DIR)/javascript \
+  --js=$(ROOT_DIR)/$(PROTOBUF_PATH)/js \
+  --js=$(NPM_DIR)/google-closure-library \
   --entry_point=goog:proto.grpc.gateway.testing.EchoServiceClient \
   --dependency_mode=PRUNE \
   --js_output_file compiled.js
@@ -64,4 +64,5 @@ install:
 
 clean:
 	rm -f compiled.js
+	rm -f *_pb.js
 	rm -rf $(OUT_DIR)

--- a/net/grpc/gateway/examples/echo/package.json
+++ b/net/grpc/gateway/examples/echo/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "echo-closure-example",
+    "version": "0.1.0",
+    "description": "gRPC-Web Closure JS client example",
+    "license": "Apache-2.0",
+    "dependencies": {},
+    "devDependencies": {
+        "google-closure-compiler": "~20200224.0.0",
+        "google-closure-library": "~20201102.0.1"
+    }
+}

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -26,6 +26,7 @@
     "@types/google-protobuf": "~3.7.0",
     "command-exists": "~1.2.8",
     "google-closure-compiler": "~20200224.0.0",
+    "google-closure-library": "~20201102.0.1",
     "google-protobuf": "~3.14.0",
     "gulp": "~4.0.2",
     "gulp-eval": "~1.0.0",

--- a/packages/grpc-web/scripts/build.js
+++ b/packages/grpc-web/scripts/build.js
@@ -27,7 +27,7 @@ const indexPath = path.relative(cwd, path.resolve(__dirname, "../index.js"));
 const jsPaths = [
   "../exports.js",
   "../../../javascript",
-  "../../../third_party/closure-library",
+  "../node_modules/google-closure-library",
 ].map(jsPath => path.relative(cwd, path.resolve(__dirname, jsPath)));
 
 const closureArgs = [].concat(

--- a/packages/grpc-web/test/generated_code_test.js
+++ b/packages/grpc-web/test/generated_code_test.js
@@ -472,7 +472,7 @@ describe('grpc-web generated code (closure+grpcwebtext)', function() {
   const jsPaths = [
     ".",
     "../../../javascript",
-    "../../../third_party/closure-library",
+    "../node_modules/google-closure-library",
     "../../../third_party/protobuf/js",
   ].map(jsPath => path.relative(cwd, path.resolve(__dirname, jsPath)));
   const closureArgs = [].concat(

--- a/scripts/init_submodules.sh
+++ b/scripts/init_submodules.sh
@@ -16,5 +16,4 @@ set -ex
 
 cd "$(dirname "$0")"/..
 git submodule --quiet update --init --recursive
-(cd third_party/closure-library && git checkout tags/v20201102)
 (cd third_party/protobuf && git checkout tags/v3.15.6)


### PR DESCRIPTION
... in favor of `google-closure-library` npm package.

This is the first step in a series of efforts to streamline our Closure dependencies.

Benefit:
- More consistent closure library and compiler versions used across code examples and the npm release.

Notable changes:
- Removed `third_party/closure-library` in favor of using the `google-closure-library` npm package.
  - Started using `google-closure-library` in both our main npm package (`packages/grpc-web`) and the echo closure example. (Retained the existing version `v20201102` used in our npm release)
  - Removed the third_party/closure-library submodule following the instructions here: https://git.wiki.kernel.org/index.php/GitSubmoduleTutorial#Removal
- Updated the `net/grpc/gateway/docker/closure_client/` to use npm `closure-compiler` rather than a custom version of java closure compiler.
  - Also tweaked its Makefile and removed references to it in the main Makefile (since it doesn't run by itself)

Tested:
- Verified that `npm run build` inside `packages/grpc-web` generates exactly the same output as before.
- Test ran `closure-client` example: `docker-compose up --build node-server envoy closure-client`
- Test ran `commonjs-client` example: `docker-compose up --build node-server envoy commonjs-client`