### PR TITLE
Internal code sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ const request = new EchoRequest();
 request.setMessage('Hello World!');
 
 const call = echoService.echo(request, {'custom-header-1': 'value1'},
-  (err: grpcWeb.Error, response: EchoResponse) => {
+  (err: grpcWeb.RpcError, response: EchoResponse) => {
     console.log(response.getMessage());
   });
 call.on('status', (status: grpcWeb.Status) => {

--- a/javascript/net/grpc/web/abstractclientbase.js
+++ b/javascript/net/grpc/web/abstractclientbase.js
@@ -28,9 +28,8 @@ goog.module.declareLegacyNamespace();
 
 
 const ClientReadableStream = goog.require('grpc.web.ClientReadableStream');
-const GrpcWebError = goog.require('grpc.web.Error');
 const MethodDescriptor = goog.require('grpc.web.MethodDescriptor');
-const MethodType = goog.require('grpc.web.MethodType');
+const RpcError = goog.require('grpc.web.RpcError');
 
 
 /**
@@ -46,10 +45,9 @@ const AbstractClientBase = class {
    * @param {string} method The method to invoke
    * @param {REQUEST} requestMessage The request proto
    * @param {!Object<string, string>} metadata User defined call metadata
-   * @param {!MethodDescriptor<REQUEST, RESPONSE>|
-   *     !AbstractClientBase.MethodInfo<REQUEST, RESPONSE>}
+   * @param {!MethodDescriptor<REQUEST, RESPONSE>}
    *   methodDescriptor Information of this RPC method
-   * @param {function(?GrpcWebError, ?)}
+   * @param {function(?RpcError, ?)}
    *   callback A callback function which takes (error, RESPONSE or null)
    * @return {!ClientReadableStream<RESPONSE>}
    */
@@ -62,8 +60,7 @@ const AbstractClientBase = class {
    * @param {string} method The method to invoke
    * @param {REQUEST} requestMessage The request proto
    * @param {!Object<string, string>} metadata User defined call metadata
-   * @param {!MethodDescriptor<REQUEST, RESPONSE>|
-   *     !AbstractClientBase.MethodInfo<REQUEST,RESPONSE>}
+   * @param {!MethodDescriptor<REQUEST, RESPONSE>}
    *   methodDescriptor Information of this RPC method
    * @return {!IThenable<RESPONSE>}
    *   A promise that resolves to the response message
@@ -76,35 +73,11 @@ const AbstractClientBase = class {
    * @param {string} method The method to invoke
    * @param {REQUEST} requestMessage The request proto
    * @param {!Object<string, string>} metadata User defined call metadata
-   * @param {!MethodDescriptor<REQUEST, RESPONSE>|
-   *     !AbstractClientBase.MethodInfo<REQUEST,RESPONSE>}
+   * @param {!MethodDescriptor<REQUEST, RESPONSE>}
    *   methodDescriptor Information of this RPC method
    * @return {!ClientReadableStream<RESPONSE>} The Client Readable Stream
    */
   serverStreaming(method, requestMessage, metadata, methodDescriptor) {}
-
-  /**
-   * As MethodType is being deprecated, for now we need to convert MethodType to
-   * MethodDescriptor.
-   * @static
-   * @template REQUEST, RESPONSE
-   * @param {string} method
-   * @param {REQUEST} requestMessage
-   * @param {!MethodType} methodType
-   * @param {!AbstractClientBase.MethodInfo<REQUEST,RESPONSE>|!MethodDescriptor<REQUEST,RESPONSE>}
-   *     methodInfo
-   * @return {!MethodDescriptor<REQUEST,RESPONSE>}
-   */
-  static ensureMethodDescriptor(
-      method, requestMessage, methodType, methodInfo) {
-    if (methodInfo instanceof MethodDescriptor) {
-      return methodInfo;
-    }
-    const requestType = methodInfo.requestType || requestMessage.constructor;
-    return new MethodDescriptor(
-        method, methodType, requestType, methodInfo.responseType,
-        methodInfo.requestSerializeFn, methodInfo.responseDeserializeFn);
-  }
 
   /**
    * Get the hostname of the current request.
@@ -117,32 +90,6 @@ const AbstractClientBase = class {
   static getHostname(method, methodDescriptor) {
     // method = hostname + methodDescriptor.name(relative path of this method)
     return method.substr(0, method.length - methodDescriptor.name.length);
-  }
-};
-
-
-/** @template REQUEST, RESPONSE */
-AbstractClientBase.MethodInfo = class {
-  /**
-   * @param {function(new: RESPONSE, ...)} responseType
-   * @param {function(REQUEST): ?} requestSerializeFn
-   * @param {function(?): RESPONSE} responseDeserializeFn
-   * @param {string=} name
-   * @param {function(new: REQUEST, ...)=} requestType
-   */
-  constructor(
-      responseType, requestSerializeFn, responseDeserializeFn, name,
-      requestType) {
-    /** @const */
-    this.name = name;
-    /** @const */
-    this.requestType = requestType;
-    /** @const */
-    this.responseType = responseType;
-    /** @const */
-    this.requestSerializeFn = requestSerializeFn;
-    /** @const */
-    this.responseDeserializeFn = responseDeserializeFn;
   }
 };
 

--- a/javascript/net/grpc/web/clientoptions.js
+++ b/javascript/net/grpc/web/clientoptions.js
@@ -1,7 +1,6 @@
 goog.module('grpc.web.ClientOptions');
 goog.module.declareLegacyNamespace();
 
-const XmlHttpFactory = goog.requireType('goog.net.XmlHttpFactory');
 const {StreamInterceptor, UnaryInterceptor} = goog.require('grpc.web.Interceptor');
 
 
@@ -47,18 +46,20 @@ class ClientOptions {
     this.format;
 
     /**
-     * The XmlHttpFactory for server-streaming calls.
-     * Example: use 'goog.net.FetchXmlHttpFactory' to reduce memory consumption
-     * during high throughput server-streaming calls.
-     * <pre>
-     * ...
-     *
-     * const xmlHttpFactory =
-     *   new FetchXmlHttpFactory({streamBinaryChunks: true});
-     * </pre>
-     * @type {!XmlHttpFactory|undefined}
+     * The Worker global scope. Once this option is specified, gRPC-Web will
+     * also use 'fetch' API as the underlying transport instead of native
+     * XmlHttpRequest.
+     * @type {!WorkerGlobalScope|undefined}
      */
-    this.streamingXmlHttpFactory;
+    this.workerScope;
+
+    /**
+     * This is an experimental feature to reduce memory consumption
+     * during high throughput server-streaming calls by using
+     * 'streamBinaryChunks' mode FetchXmlHttpFactory.
+     * @type {boolean|undefined}
+     */
+    this.useFetchDownloadStreams;
   }
 }
 

--- a/javascript/net/grpc/web/clientreadablestream.js
+++ b/javascript/net/grpc/web/clientreadablestream.js
@@ -45,6 +45,21 @@ const ClientReadableStream = function() {};
 /**
  * Register a callback to handle different stream events.
  *
+ * Available event types for gRPC-Web:
+ * 'data': The 'data' event is emitted when a new response message chunk is
+ * received and successfully handled by gRPC-Web client.
+ * 'status': the google RPC status of the response stream.
+ * 'end': The 'end' event is emitted when all the data have been successfully
+ * consumed from the stream.
+ * 'error': typically, this may occur when an  underlying internal failure
+ * happens, or a stream implementation attempts to push an invalid chunk of
+ * data.
+ * 'metadata': the response metadata. Response headers should be read via
+ * 'metadata' callbacks.
+ *
+ * For server-streaming calls. the 'data' and 'status' callbacks (if exist)
+ * will always precede 'metadata', 'error', or 'end' callbacks.
+ *
  * @param {string} eventType The event type
  * @param {function(?)} callback The callback to handle the event with
  * an optional input object

--- a/javascript/net/grpc/web/methodtype.js
+++ b/javascript/net/grpc/web/methodtype.js
@@ -1,7 +1,5 @@
 /**
- * @fileoverview Description of this file.
- *
- * grpc web MethodType
+ * @fileoverview gRPC-Web method types.
  */
 
 goog.module('grpc.web.MethodType');
@@ -9,15 +7,18 @@ goog.module('grpc.web.MethodType');
 goog.module.declareLegacyNamespace();
 
 /**
- * See grpc.web.AbstractClientBase.
- * MethodType.UNARY for rpcCall/unaryCall.
- * MethodType.SERVER_STREAMING for serverStreaming.
+ * Available method types:
+ * MethodType.UNARY: unary request and unary response.
+ * MethodType.SERVER_STREAMING: unary request and streaming responses.
+ * MethodType.BIDI_STREAMING: streaming requests and streaming responses.
  *
  * @enum {string}
  */
 const MethodType = {
   'UNARY': 'unary',
-  'SERVER_STREAMING': 'server_streaming'
+  'SERVER_STREAMING': 'server_streaming',
+  // Bidi streaming is experimental. Do not use.
+  'BIDI_STREAMING': 'bidi_streaming',
 };
 
 exports = MethodType;

--- a/javascript/net/grpc/web/rpcerror.js
+++ b/javascript/net/grpc/web/rpcerror.js
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright 2018 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,25 +20,29 @@
  *
  * gRPC-Web Error objects
  *
- * @author stanleycheung@google.com (Stanley Cheung)
+ * @suppress {lintChecks} gRPC-Web is still using default goog.module exports
+ * right now, and the output of grpc_generator.cc uses goog.provide.
  */
-goog.module('grpc.web.Error');
-
-goog.module.declareLegacyNamespace();
+goog.module('grpc.web.RpcError');
 
 const Metadata = goog.require('grpc.web.Metadata');
 
+class RpcError extends Error {
+  /**
+   * @param {number} code
+   * @param {string} message
+   * @param {!Metadata=} metadata
+   */
+  constructor(code, message, metadata = {}) {
+    super(message);
+    /** @type {number} */
+    this.code = code;
+    /** @type {!Metadata} */
+    this.metadata = metadata;
+  }
+}
 
-/** @record */
-function Error() {}
+/** @override */
+RpcError.prototype.name = 'RpcError';
 
-/** @export {(number|undefined)} */
-Error.prototype.code;
-
-/** @export {(string|undefined)} */
-Error.prototype.message;
-
-/** @export {(?Metadata|undefined)} */
-Error.prototype.metadata;
-
-exports = Error;
+exports = RpcError;

--- a/net/grpc/gateway/examples/echo/commonjs-example/echotest.html
+++ b/net/grpc/gateway/examples/echo/commonjs-example/echotest.html
@@ -32,7 +32,7 @@
             </button>
           </span>
         </div>
-        <p class="help-block">Example: "Hello", "4 Hello"</p>
+        <p class="help-block">Example: "Hello", "4 Hello", "err Hello"</p>
       </div>
     </div>
   </div>

--- a/net/grpc/gateway/examples/echo/echoapp.js
+++ b/net/grpc/gateway/examples/echo/echoapp.js
@@ -86,7 +86,7 @@ echoapp.EchoApp.prototype.echo = function(msg) {
  * @param {string} msg
  */
 echoapp.EchoApp.prototype.echoError = function(msg) {
-  echoapp.EchoApp.addLeftMessage(msg);
+  echoapp.EchoApp.addLeftMessage(`Error: ${msg}`);
   var unaryRequest = new this.ctors.EchoRequest();
   unaryRequest.setMessage(msg);
   this.echoService.echoAbort(unaryRequest, {}, function(err, response) {

--- a/net/grpc/gateway/examples/echo/echotest.html
+++ b/net/grpc/gateway/examples/echo/echotest.html
@@ -48,7 +48,7 @@ const module = {};
             </button>
           </span>
         </div>
-        <p class="help-block">Example: "Hello", "4 Hello"</p>
+        <p class="help-block">Example: "Hello", "4 Hello", "err Hello"</p>
       </div>
     </div>
   </div>

--- a/net/grpc/gateway/examples/echo/ts-example/echotest.html
+++ b/net/grpc/gateway/examples/echo/ts-example/echotest.html
@@ -32,7 +32,7 @@
             </button>
           </span>
         </div>
-        <p class="help-block">Example: "Hello", "4 Hello"</p>
+        <p class="help-block">Example: "Hello", "4 Hello", "err Hello"</p>
       </div>
     </div>
   </div>

--- a/packages/grpc-web/README.md
+++ b/packages/grpc-web/README.md
@@ -8,7 +8,7 @@ gRPC-Web is now Generally Available, and considered stable enough for production
 
 gRPC-Web clients connect to gRPC services via a special gateway proxy: the
 current version of the library uses [Envoy](https://www.envoyproxy.io/) by
-default, in which gRPC-Web support is built-in. 
+default, in which gRPC-Web support is built-in.
 
 In the future, we expect gRPC-Web to be supported in language-specific Web
 frameworks, such as Python, Java, and Node. See the
@@ -113,7 +113,7 @@ const request = new EchoRequest();
 request.setMessage('Hello World!');
 
 const call = echoService.echo(request, {'custom-header-1': 'value1'},
-  (err: grpcWeb.Error, response: EchoResponse) => {
+  (err: grpcWeb.RpcError, response: EchoResponse) => {
     console.log(response.getMessage());
   });
 call.on('status', (status: grpcWeb.Status) => {

--- a/packages/grpc-web/exports.js
+++ b/packages/grpc-web/exports.js
@@ -6,13 +6,11 @@
  */
 goog.module('grpc.web.Exports');
 
-const AbstractClientBase = goog.require('grpc.web.AbstractClientBase');
 const GrpcWebClientBase = goog.require('grpc.web.GrpcWebClientBase');
 const StatusCode = goog.require('grpc.web.StatusCode');
 const MethodDescriptor = goog.require('grpc.web.MethodDescriptor');
 const MethodType = goog.require('grpc.web.MethodType');
 
-module['exports']['AbstractClientBase'] = {'MethodInfo': AbstractClientBase.MethodInfo};
 module['exports']['GrpcWebClientBase'] = GrpcWebClientBase;
 module['exports']['StatusCode'] = StatusCode;
 module['exports']['MethodDescriptor'] = MethodDescriptor;

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -2,41 +2,33 @@ declare module "grpc-web" {
 
   export interface Metadata { [s: string]: string; }
 
-  export namespace AbstractClientBase {
-    class MethodInfo<REQ, RESP> {
-      constructor (responseType: new () => RESP,
-                   requestSerializeFn: (request: REQ) => {},
-                   responseDeserializeFn: (bytes: Uint8Array) => RESP);
-    }
-  }
-
   export class AbstractClientBase {
     thenableCall<REQ, RESP> (
       method: string,
       request: REQ,
       metadata: Metadata,
-      methodDescriptor: MethodDescriptor<REQ, RESP> | AbstractClientBase.MethodInfo<REQ, RESP>
+      methodDescriptor: MethodDescriptor<REQ, RESP>
     ): Promise<RESP>;
 
     rpcCall<REQ, RESP> (
       method: string,
       request: REQ,
       metadata: Metadata,
-      methodDescriptor: MethodDescriptor<REQ, RESP> | AbstractClientBase.MethodInfo<REQ, RESP>,
-      callback: (err: Error, response: RESP) => void
+      methodDescriptor: MethodDescriptor<REQ, RESP>,
+      callback: (err: RpcError, response: RESP) => void
     ): ClientReadableStream<RESP>;
 
     serverStreaming<REQ, RESP> (
       method: string,
       request: REQ,
       metadata: Metadata,
-      methodDescriptor: MethodDescriptor<REQ, RESP> | AbstractClientBase.MethodInfo<REQ, RESP>
+      methodDescriptor: MethodDescriptor<REQ, RESP>
     ): ClientReadableStream<RESP>;
   }
 
   export class ClientReadableStream<RESP> {
     on (eventType: "error",
-        callback: (err: Error) => void): ClientReadableStream<RESP>;
+        callback: (err: RpcError) => void): ClientReadableStream<RESP>;
     on (eventType: "status",
         callback: (status: Status) => void): ClientReadableStream<RESP>;
     on (eventType: "metadata",
@@ -47,7 +39,7 @@ declare module "grpc-web" {
         callback: () => void): ClientReadableStream<RESP>;
 
     removeListener (eventType: "error",
-                    callback: (err: Error) => void): void;
+                    callback: (err: RpcError) => void): void;
     removeListener (eventType: "status",
                     callback: (status: Status) => void): void;
     removeListener (eventType: "metadata",
@@ -56,7 +48,7 @@ declare module "grpc-web" {
                     callback: (response: RESP) => void): void;
     removeListener (eventType: "end",
                     callback: () => void): void;
-                    
+
     cancel (): void;
   }
 
@@ -96,14 +88,14 @@ declare module "grpc-web" {
     getResponseDeserializeFn(): any;
     getRequestSerializeFn(): any;
   }
-  
+
   export class Request<REQ, RESP> {
     getRequestMessage(): REQ;
     getMethodDescriptor(): MethodDescriptor<REQ, RESP>;
     getMetadata(): Metadata;
     getCallOptions(): CallOptions;
   }
-  
+
   export class UnaryResponse<REQ, RESP> {
     getResponseMessage(): RESP;
     getMetadata(): Metadata;
@@ -123,9 +115,10 @@ declare module "grpc-web" {
     constructor(options?: GrpcWebClientBaseOptions);
   }
 
-  export interface Error {
-    code: number;
-    message: string;
+  export class RpcError extends Error {
+    constructor(code: StatusCode, message: string, metadata: Metadata);
+    code: StatusCode;
+    metadata: Metadata;
   }
 
   export interface Status {
@@ -134,24 +127,24 @@ declare module "grpc-web" {
     metadata?: Metadata;
   }
 
-  export namespace StatusCode {
-    const ABORTED: number;
-    const ALREADY_EXISTS: number;
-    const CANCELLED: number;
-    const DATA_LOSS: number;
-    const DEADLINE_EXCEEDED: number;
-    const FAILED_PRECONDITION: number;
-    const INTERNAL: number;
-    const INVALID_ARGUMENT: number;
-    const NOT_FOUND: number;
-    const OK: number;
-    const OUT_OF_RANGE: number;
-    const PERMISSION_DENIED: number;
-    const RESOURCE_EXHAUSTED: number;
-    const UNAUTHENTICATED: number;
-    const UNAVAILABLE: number;
-    const UNIMPLEMENTED: number;
-    const UNKNOWN: number;
+  export enum StatusCode {
+    ABORTED,
+    ALREADY_EXISTS,
+    CANCELLED,
+    DATA_LOSS,
+    DEADLINE_EXCEEDED,
+    FAILED_PRECONDITION,
+    INTERNAL,
+    INVALID_ARGUMENT,
+    NOT_FOUND,
+    OK,
+    OUT_OF_RANGE,
+    PERMISSION_DENIED,
+    RESOURCE_EXHAUSTED,
+    UNAUTHENTICATED,
+    UNAVAILABLE,
+    UNIMPLEMENTED,
+    UNKNOWN,
   }
 
   export namespace MethodType {

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -29,7 +29,7 @@
     "command-exists": "~1.2.8",
     "google-closure-compiler": "~20200224.0.0",
     "google-closure-deps": "~20210601.0.0",
-    "google-closure-library": "~20201102.0.1",
+    "google-closure-library": "~20210808.0.0",
     "google-protobuf": "~3.14.0",
     "gulp": "~4.0.2",
     "gulp-connect": "~5.7.0",

--- a/packages/grpc-web/protractor_spec.js
+++ b/packages/grpc-web/protractor_spec.js
@@ -98,6 +98,10 @@ describe('Run all Closure unit tests', function() {
     });
   });
 
+  if (!allTests.length) {
+    throw new Error('Cannot find any JsUnit tests!!');
+  }
+
   // Run all tests.
   for (var i = 0; i < allTests.length; i++) {
     var testPath = allTests[i];

--- a/packages/grpc-web/test/export_test.js
+++ b/packages/grpc-web/test/export_test.js
@@ -3,10 +3,6 @@ const grpc = {};
 grpc.web = require('grpc-web');
 
 describe('grpc-web export test', function() {
-  it('should have AbstractClientBase.MethodInfo exported', function() {
-    assert.equal(typeof grpc.web.AbstractClientBase.MethodInfo, 'function');
-  });
-
   it('should have MethodDescriptor exported', function() {
     assert.equal(typeof grpc.web.MethodDescriptor, 'function');
   });

--- a/packages/grpc-web/test/tsc-tests/client02.ts
+++ b/packages/grpc-web/test/tsc-tests/client02.ts
@@ -23,5 +23,5 @@ import {MyServiceClient} from './generated/Test02ServiceClientPb';
 const service = new MyServiceClient('http://mydummy.com', null, null);
 const req = new Integer();
 
-service.addOne(req, {}, (err: grpcWeb.Error, resp: Integer) => {
+service.addOne(req, {}, (err: grpcWeb.RpcError, resp: Integer) => {
 });

--- a/packages/grpc-web/test/tsc-tests/client05.ts
+++ b/packages/grpc-web/test/tsc-tests/client05.ts
@@ -30,7 +30,7 @@ req.setMessage('aaa');
 // this test tries to make sure that these types are as accurate as possible
 
 let call1 : grpcWeb.ClientReadableStream<EchoResponse> =
-  echoService.echo(req, {}, (err: grpcWeb.Error,
+  echoService.echo(req, {}, (err: grpcWeb.RpcError,
                              response: EchoResponse) => {
                              });
 
@@ -46,5 +46,5 @@ let call2 : grpcWeb.ClientReadableStream<ServerStreamingEchoResponse> =
 call2
   .on('data', (response: ServerStreamingEchoResponse) => {
   })
-  .on('error', (error: grpcWeb.Error) => {
+  .on('error', (error: grpcWeb.RpcError) => {
   });


### PR DESCRIPTION
### Summary
  * Internal code sync (up to Aug 4, 2021 for now..) & relevant improvements. :)
  * Updated Closure dependency to `20210808.0.0` (necessary dependency)

### Main code changes:
  * Improving error typing to use type `RpcError` in favor of untyped `Error`
    * Also updated `StatusCode` to be a enum (not full enum support (e.g. `RpcError[RpcError.OK] === 'OK'`) is there but general `===` comparison should work)
  * Removed `AbstractClientBase.MethodInfo`

### Other changes:
  * Unifying error behavior in TS and JS echo examples
  * Improved jsunit test runner to throw error when no unit test was found

### TODO:
  * https://github.com/grpc/grpc-web/pull/1063 is clobbered now so we need to redo it as a follow-up.