### PR TITLE
Adding `-static` to generator g++ build flag

### DIFF
--- a/javascript/net/grpc/web/generator/Makefile
+++ b/javascript/net/grpc/web/generator/Makefile
@@ -15,7 +15,7 @@
 CXX ?= g++
 CPPFLAGS += -I/usr/local/include -pthread
 CXXFLAGS += -std=c++11
-LDFLAGS += -L/usr/local/lib -lprotoc -lprotobuf -lpthread -ldl
+LDFLAGS += -L/usr/local/lib -lprotoc -lprotobuf -lpthread -ldl -static
 PREFIX ?= /usr/local
 
 all: protoc-gen-grpc-web


### PR DESCRIPTION
This flag is needed for release and seems harmless according to documentation:
https://linux.die.net/man/1/g++