### PR TITLE
Update instructions to pull the `prereqs` image for the Echo App

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ streaming example.
 From the repo root directory:
 
 ```sh
-$ docker-compose pull node-server envoy commonjs-client
+$ docker-compose pull prereqs node-server envoy commonjs-client
 $ docker-compose up node-server envoy commonjs-client
 ```
 


### PR DESCRIPTION
As it's currently specified as a runtime dependency (in `docker-compose.yml`), even tho it's technically only needed at build time.

(Ideas needed: Anyone has idea on how to specify an image dependency to be build-time only in docker-compose? 😃)