### PR TITLE
Add missing exports from RpcError and add test.

### DIFF
--- a/javascript/net/grpc/web/rpcerror.js
+++ b/javascript/net/grpc/web/rpcerror.js
@@ -40,9 +40,9 @@ class RpcError extends Error {
    */
   constructor(code, message, metadata = {}) {
     super(message);
-    /** @type {!StatusCode} */
+    /** @export {!StatusCode} */
     this.code = code;
-    /** @type {!Metadata} */
+    /** @export {!Metadata} */
     this.metadata = metadata;
   }
 }

--- a/packages/grpc-web/test/export_test.js
+++ b/packages/grpc-web/test/export_test.js
@@ -15,7 +15,14 @@ describe('grpc-web export test', function() {
     assert.equal(typeof grpc.web.GrpcWebClientBase.prototype.serverStreaming, 'function');
   });
 
-  it('should have grpc StatusCode exported', function() {
+  it('should have RpcError properties exported', function() {
+    const rpcError = new grpc.web.RpcError(/* code= */ 0, 'message');
+    assert.equal(typeof rpcError.code, 'number');
+    assert.equal(typeof rpcError.message, 'string');
+    assert.equal(typeof rpcError.metadata, 'object');
+  });
+
+  it('should have StatusCode exported', function() {
     assert.deepEqual(grpc.web.StatusCode, {
       ABORTED: 10,
       ALREADY_EXISTS: 6,


### PR DESCRIPTION
This complements https://github.com/grpc/grpc-web/pull/1164 to ensure the properties of `RpcError` are exported as well, and add tests.

(btw even without the `@export` annotation these 2 fields are exported today, but that's somewhat by accident -- it's due to them being referred by other classed rather than guaranteed.)