### PR TITLE
Fix missing TypeScript return type for `serverStreaming` calls.

### DIFF
--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -600,8 +600,7 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
                                 : "grpcWeb.MethodType.UNARY";
       if (!method->client_streaming()) {
         printer->Print(vars,
-                       "methodDescriptor$method_name$: "
-                       "grpcWeb.MethodDescriptor<$input_type$, $output_type$> = "
+                       "methodDescriptor$method_name$ = "
                        "new grpcWeb.MethodDescriptor(\n");
         printer->Indent();
         printer->Print(vars,

--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -600,7 +600,8 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
                                 : "grpcWeb.MethodType.UNARY";
       if (!method->client_streaming()) {
         printer->Print(vars,
-                       "methodDescriptor$method_name$ = "
+                       "methodDescriptor$method_name$: "
+                       "grpcWeb.MethodDescriptor<$input_type$, $output_type$> = "
                        "new grpcWeb.MethodDescriptor(\n");
         printer->Indent();
         printer->Print(vars,
@@ -619,7 +620,8 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Indent();
           printer->Print(vars,
                          "request: $input_type$,\n"
-                         "metadata?: grpcWeb.Metadata) {\n");
+                         "metadata?: grpcWeb.Metadata): "
+                         "grpcWeb.ClientReadableStream<$output_type$> {\n");
           printer->Print(vars, "return this.client_.serverStreaming(\n");
           printer->Indent();
           printer->Print(vars,

--- a/packages/grpc-web/exports.js
+++ b/packages/grpc-web/exports.js
@@ -6,12 +6,16 @@
  */
 goog.module('grpc.web.Exports');
 
-const GrpcWebClientBase = goog.require('grpc.web.GrpcWebClientBase');
-const StatusCode = goog.require('grpc.web.StatusCode');
+const CallOptions = goog.require('grpc.web.CallOptions');
 const MethodDescriptor = goog.require('grpc.web.MethodDescriptor');
+const GrpcWebClientBase = goog.require('grpc.web.GrpcWebClientBase');
+const RpcError = goog.require('grpc.web.RpcError');
+const StatusCode = goog.require('grpc.web.StatusCode');
 const MethodType = goog.require('grpc.web.MethodType');
 
-module['exports']['GrpcWebClientBase'] = GrpcWebClientBase;
-module['exports']['StatusCode'] = StatusCode;
+module['exports']['CallOptions'] = CallOptions;
 module['exports']['MethodDescriptor'] = MethodDescriptor;
+module['exports']['GrpcWebClientBase'] = GrpcWebClientBase;
+module['exports']['RpcError'] = RpcError;
+module['exports']['StatusCode'] = StatusCode;
 module['exports']['MethodType'] = MethodType;

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -83,10 +83,10 @@ declare module "grpc-web" {
                         status?: Status): UnaryResponse<REQ, RESP>;
     getName(): string;
     getMethodType(): string;
-    getResponseMessageCtor(): any;
-    getRequestMessageCtor(): any;
-    getResponseDeserializeFn(): any;
-    getRequestSerializeFn(): any;
+    getRequestMessageCtor(): new (...args: unknown[]) => REQ;
+    getResponseMessageCtor(): new (...args: unknown[]) => RESP;
+    getRequestSerializeFn(): (request: REQ) => Uint8Array;
+    getResponseDeserializeFn(): (bytes: Uint8Array) => RESP;
   }
 
   export class Request<REQ, RESP> {

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -71,8 +71,8 @@ declare module "grpc-web" {
   export class MethodDescriptor<REQ, RESP> {
     constructor(name: string,
                 methodType: string,
-                requestType: new (...args: unknown[]) => REQ,
-                responseType: new (...args: unknown[]) => RESP,
+                requestType: any,
+                responseType: any,
                 requestSerializeFn: (request: REQ) => Uint8Array,
                 responseDeserializeFn: (bytes: Uint8Array) => RESP);
     createRequest(requestMessage: REQ,
@@ -85,8 +85,8 @@ declare module "grpc-web" {
     getMethodType(): string;
     getRequestMessageCtor(): new (...args: unknown[]) => REQ;
     getResponseMessageCtor(): new (...args: unknown[]) => RESP;
-    getRequestSerializeFn(): (request: REQ) => Uint8Array;
-    getResponseDeserializeFn(): (bytes: Uint8Array) => RESP;
+    getRequestSerializeFn(): any;
+    getResponseDeserializeFn(): any;
   }
 
   export class Request<REQ, RESP> {

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -71,10 +71,10 @@ declare module "grpc-web" {
   export class MethodDescriptor<REQ, RESP> {
     constructor(name: string,
                 methodType: string,
-                requestType: any,
-                responseType: any,
-                requestSerializeFn: (request: REQ) => Uint8Array,
-                responseDeserializeFn: (bytes: Uint8Array) => RESP);
+                requestType: new (...args: unknown[]) => REQ,
+                responseType: new (...args: unknown[]) => RESP,
+                requestSerializeFn: any,
+                responseDeserializeFn: any);
     createRequest(requestMessage: REQ,
                   metadata?: Metadata,
                   callOptions?: CallOptions): Request<REQ, RESP>;

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -70,11 +70,11 @@ declare module "grpc-web" {
 
   export class MethodDescriptor<REQ, RESP> {
     constructor(name: string,
-                methodType: any,
-                requestType: any,
-                responseType: any,
-                requestSerializeFn: any,
-                responseDeserializeFn: any);
+                methodType: string,
+                requestType: new (...args: unknown[]) => REQ,
+                responseType: new (...args: unknown[]) => RESP,
+                requestSerializeFn: (request: REQ) => Uint8Array,
+                responseDeserializeFn: (bytes: Uint8Array) => RESP);
     createRequest(requestMessage: REQ,
                   metadata?: Metadata,
                   callOptions?: CallOptions): Request<REQ, RESP>;


### PR DESCRIPTION
Should fix #950 

In the generated typescript code this will ensure that the generic parameters will be inferred from the values passed to the constructor. This should only make a difference when the `import_style` setting is set to `typescript`. Afterwards in the following code snippet the the response parameter will correctly infer to `ServerStreamingEchoResponse`, whereas previously it would be typed as `unknown`.

```ts
import * as grpcWeb from 'grpc-web';

import {EchoRequest, EchoResponse,
        ServerStreamingEchoRequest,
        ServerStreamingEchoResponse} from './generated/echo_pb';
import {EchoServiceClient} from './generated/EchoServiceClientPb';

const echoService = new EchoServiceClient('http://localhost:8080', null, null);

let call2 =
  echoService.serverStreamingEcho(new ServerStreamingEchoRequest(), {});

call2
  .on('data', (response) => {
  })
  .on('error', (error: grpcWeb.RpcError) => {
  });
```

I am not entirely sure where tests for the `typescript` mode are located, I was only able to finde the `tsc_tests`, but they seem to be using the dts generator.