### PR TITLE
Pin typescript @`4.4.4` to fix CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+**/dist
 **/node_modules
 packages/grpc-web/generated

--- a/net/grpc/gateway/docker/ts_client/Dockerfile
+++ b/net/grpc/gateway/docker/ts_client/Dockerfile
@@ -14,8 +14,6 @@
 
 FROM grpcweb/prereqs
 
-RUN npm install -g typescript
-
 WORKDIR /github/grpc-web/net/grpc/gateway/examples/echo
 
 RUN protoc -I=. echo.proto \
@@ -26,7 +24,7 @@ WORKDIR /github/grpc-web/net/grpc/gateway/examples/echo/ts-example
 
 RUN npm install && \
   npm link grpc-web && \
-  tsc && \
+  npx tsc && \
   npx webpack && \
   cp echotest.html /var/www/html && \
   cp dist/main.js /var/www/html/dist

--- a/net/grpc/gateway/examples/echo/ts-example/package.json
+++ b/net/grpc/gateway/examples/echo/ts-example/package.json
@@ -1,5 +1,5 @@
 {
-  "dependencies": {
+  "devDependencies": {
     "@types/google-protobuf": "~3.7.0",
     "@types/jquery": "~3.3.6",
     "@types/node": "~10.17.0",
@@ -7,6 +7,7 @@
     "grpc-web": "~1.3.0",
     "jquery": "~3.5.1",
     "mock-xmlhttprequest": "~2.0.0",
+    "typescript": "~4.4.4",
     "webpack": "~4.43.0",
     "webpack-cli": "~3.3.11"
   }

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -37,6 +37,6 @@
     "mocha": "~5.2.0",
     "mock-xmlhttprequest": "~2.0.0",
     "protractor": "~7.0.0",
-    "typescript": "~3.8.0"
+    "typescript": "~4.4.4"
   }
 }


### PR DESCRIPTION
CI broke today due to [`typescript`](https://www.npmjs.com/package/typescript) updating to `4.5.2` ([release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/)). Pinning it down to `4.4.4` to fix CI.

It appears that `4.5.2` stop generating `echo_grpc_web_pb.js` and `echo_pb.js` files in the `dist/` directory, despite there being corresponding `.d.ts` files.

Ideas on why and a proper fix (e.g. maybe we should just copy the files into `dist/` ourselves?) are very welcome.. :)