### PR TITLE
Use latest typescript and manually move `*_pb.js` files into `dist/`

### DIFF
--- a/net/grpc/gateway/docker/ts_client/Dockerfile
+++ b/net/grpc/gateway/docker/ts_client/Dockerfile
@@ -25,6 +25,9 @@ WORKDIR /github/grpc-web/net/grpc/gateway/examples/echo/ts-example
 RUN npm install && \
   npm link grpc-web && \
   npx tsc && \
+  # Since typescript@4.5.2, tsc has apparently stopped moving dependent js files into dist/ dir, so
+  # we'll move them manually.
+  mv *_pb.js dist/ && \
   npx webpack && \
   cp echotest.html /var/www/html && \
   cp dist/main.js /var/www/html/dist

--- a/net/grpc/gateway/examples/echo/ts-example/package.json
+++ b/net/grpc/gateway/examples/echo/ts-example/package.json
@@ -7,7 +7,7 @@
     "grpc-web": "~1.3.0",
     "jquery": "~3.5.1",
     "mock-xmlhttprequest": "~2.0.0",
-    "typescript": "~4.4.4",
+    "typescript": "latest",
     "webpack": "~4.43.0",
     "webpack-cli": "~3.3.11"
   }

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -37,6 +37,6 @@
     "mocha": "~5.2.0",
     "mock-xmlhttprequest": "~2.0.0",
     "protractor": "~7.0.0",
-    "typescript": "~4.4.4"
+    "typescript": "latest"
   }
 }


### PR DESCRIPTION
See https://github.com/grpc/grpc-web/pull/1170 for the issue caused by change in typescript `4.5.2` and why this is needed.