### PR TITLE
Fix issue where no RPC is issued when `deadline` is specified.

### DIFF
--- a/packages/grpc-web/exports.js
+++ b/packages/grpc-web/exports.js
@@ -19,3 +19,9 @@ module['exports']['GrpcWebClientBase'] = GrpcWebClientBase;
 module['exports']['RpcError'] = RpcError;
 module['exports']['StatusCode'] = StatusCode;
 module['exports']['MethodType'] = MethodType;
+
+// Temporary hack to fix https://github.com/grpc/grpc-web/issues/1153, which is
+// caused by `goog.global` not pointing to the global scope when grpc-web is
+// being imported as a CommonJS module.
+// TODO: Remove this hack after `goog.global` is fixed.
+goog.Timer.defaultTimerObject =  (typeof globalThis !== "undefined" && globalThis) || self;

--- a/test/interop/interop_client.js
+++ b/test/interop/interop_client.js
@@ -50,6 +50,17 @@ function doEmptyUnary(done) {
   });
 }
 
+function doEmptyUnaryWithDeadline(done) {
+  var testService = new TestServiceClient(SERVER_HOST, null, null);
+  const deadlineMs = 1000; // 1 second
+  testService.emptyCall(new Empty(), {deadline: Date.now() + deadlineMs},
+    (err, response) => {
+      assert.ifError(err);
+      assert(response instanceof Empty);
+      done();
+    });
+}
+
 function doLargeUnary(done) {
   var testService = new TestServiceClient(SERVER_HOST, null, null);
   var req = new SimpleRequest();
@@ -167,6 +178,7 @@ function doUnimplementedMethod(done) {
 
 var testCases = {
   'empty_unary': {testFunc: doEmptyUnary},
+  'empty_unary_with_deadline': {testFunc: doEmptyUnaryWithDeadline},
   'large_unary': {testFunc: doLargeUnary},
   'server_streaming': {testFunc: doServerStreaming,
                        skipBinaryMode: true},


### PR DESCRIPTION
### The issue

This is a temporary hack to fix https://github.com/grpc/grpc-web/issues/1153, which is caused by [`goog.global`](https://github.com/google/closure-library/blob/f7c1a98dfed9e77a458817ff877c7336079ce3bf/closure/goog/base.js#L47-L56) not properly pointing to the proper global scope (e.g. `window`) when grpc-web is being imported as a CommonJS module (because [`this`](https://github.com/google/closure-library/blob/f7c1a98dfed9e77a458817ff877c7336079ce3bf/closure/goog/base.js#L48-L53) points to the module scope instead of actual global scope (i.e. `globalThis`)).

`goog.Timer.defaultTimerObject` is set to [point to](https://github.com/google/closure-library/blob/f7c1a98dfed9e77a458817ff877c7336079ce3bf/closure/goog/timer/timer.js#L112) `goog.global`, and that's why it throws when `setTimeout` is [called](https://github.com/google/closure-library/blob/f7c1a98dfed9e77a458817ff877c7336079ce3bf/closure/goog/timer/timer.js#L290) on it.

### The fix

* In this fix, we'll try to use [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) when possible, and if it's not available (pre-2020 browsers, etc.), fallback to [`self`](https://developer.mozilla.org/en-US/docs/Web/API/Window/self), which should work in both browsers and workers.
* Also added an interop test to verify the fix works (the new test fails without the fix)