### PR TITLE
Update envoy version to 1.20

### DIFF
--- a/net/grpc/gateway/docker/envoy/Dockerfile
+++ b/net/grpc/gateway/docker/envoy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM envoyproxy/envoy:v1.17.0
+FROM envoyproxy/envoy:v1.20.0
 
 COPY net/grpc/gateway/examples/echo/envoy.yaml /etc/envoy/envoy.yaml
 

--- a/net/grpc/gateway/examples/helloworld/README.md
+++ b/net/grpc/gateway/examples/helloworld/README.md
@@ -307,7 +307,7 @@ run the 3 processes all in the background.
 
  ```sh
  $ docker run -d -v "$(pwd)"/envoy.yaml:/etc/envoy/envoy.yaml:ro \
-     --network=host envoyproxy/envoy:v1.17.0
+     --network=host envoyproxy/envoy:v1.20.0
  ```
 
 > NOTE: As per [this issue](https://github.com/grpc/grpc-web/issues/436):
@@ -315,7 +315,7 @@ run the 3 processes all in the background.
 >
 > ```sh
 > $ docker run -d -v "$(pwd)"/envoy.yaml:/etc/envoy/envoy.yaml:ro \
->     -p 8080:8080 -p 9901:9901 envoyproxy/envoy:v1.17.0
+>     -p 8080:8080 -p 9901:9901 envoyproxy/envoy:v1.20.0
 >  ```
 
  3. Run the simple Web Server. This hosts the static file `index.html` and

--- a/scripts/run_interop_tests.sh
+++ b/scripts/run_interop_tests.sh
@@ -43,7 +43,7 @@ docker-compose build prereqs node-interop-server java-interop-server
 echo -e "\n[Running] Interop test #1 - against Envoy"
 pid1=$(docker run -d \
   -v "$(pwd)"/test/interop/envoy.yaml:/etc/envoy/envoy.yaml:ro \
-  --network=host envoyproxy/envoy:v1.17.0)
+  --network=host envoyproxy/envoy:v1.20.0)
 pid2=$(docker run -d --network=host grpcweb/node-interop-server)
 
 run_tests

--- a/test/interop/README.md
+++ b/test/interop/README.md
@@ -33,7 +33,7 @@ tests.
 
 ```sh
 $ docker run -d -v $(pwd)/test/interop/envoy.yaml:/etc/envoy/envoy.yaml:ro \
-  --network=host envoyproxy/envoy:v1.17.0
+  --network=host envoyproxy/envoy:v1.20.0
 ```
 
 


### PR DESCRIPTION
Sometimes Envoy has breaking changes when upgrading between versions. Looks like we are clear this time.