### PR TITLE
Remove outdated limitation regarding format mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,11 @@ For more information about the gRPC-web wire format, see the
 
   - `Content-type: application/grpc-web-text`
   - Payload are base64-encoded.
-  - Both unary and server streaming calls are supported.
 
 `mode=grpcweb`: A binary protobuf format is also supported.
 
   - `Content-type: application/grpc-web+proto`
   - Payload are in the binary protobuf format.
-  - Only unary calls are supported for now.
 
 ## How It Works
 


### PR DESCRIPTION
The README states that "only unary calls are supported for now" regarding the `mode=grpcweb` (binary protobuf format).
I have a server streaming call and am generating typescript code with the following, it seems to work.

```
protoc \
    --proto_path=./ \
    --plugin=protoc-gen-grpc-web=/usr/local/grpc-web/protoc-gen-grpc-web \
    --js_out=import_style=commonjs,binary:${OUT_DIR} \
    --grpc-web_out=import_style=typescript,mode=grpcweb:${OUT_DIR} \
    ${INPUT_FILE}
```

Also it seems this is tested: scripts/docker-run-interop-tests.sh

Am I missing something?