### PR TITLE
Disable caching of local generated `/dist/main.js` file in echo examples

### DIFF
--- a/net/grpc/gateway/examples/echo/commonjs-example/echotest.html
+++ b/net/grpc/gateway/examples/echo/commonjs-example/echotest.html
@@ -19,7 +19,12 @@
 <title>Echo Example</title>
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 <script src="//ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-<script src="./dist/main.js"></script>
+<script>
+  // Load the local /dist/main.js and use a random query parameter to disable caching.
+  const script = document.createElement('script');
+  script.src = `./dist/main.js?v=${Date.now()}`;
+  document.head.appendChild(script);
+</script>
 </head>
 <body>
   <div class="container">

--- a/net/grpc/gateway/examples/echo/ts-example/echotest.html
+++ b/net/grpc/gateway/examples/echo/ts-example/echotest.html
@@ -19,7 +19,12 @@
 <title>Echo Example</title>
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 <script src="//ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-<script src="./dist/main.js"></script>
+<script>
+  // Load the local /dist/main.js and use a random query parameter to disable caching.
+  const script = document.createElement('script');
+  script.src = `./dist/main.js?v=${Date.now()}`;
+  document.head.appendChild(script);
+</script>
 </head>
 <body>
   <div class="container">


### PR DESCRIPTION
It could be confusing sometimes when locally generated javascript are not loaded due to browser caching.. :)