### PR TITLE
Revert "Expose MethodDescriptor's public methods"

### DIFF
--- a/javascript/net/grpc/web/methoddescriptor.js
+++ b/javascript/net/grpc/web/methoddescriptor.js
@@ -74,7 +74,6 @@ const MethodDescriptor = class {
 
   /**
    * @override
-   * @export
    */
   getName() {
     return this.name;
@@ -82,7 +81,6 @@ const MethodDescriptor = class {
 
   /**
    * @override
-   * @export
    */
   getMethodType() {
     return this.methodType;
@@ -90,7 +88,6 @@ const MethodDescriptor = class {
 
   /**
    * @override
-   * @export
    * @return {function(new: RESPONSE, ...)}
    */
   getResponseMessageCtor() {
@@ -99,25 +96,18 @@ const MethodDescriptor = class {
 
   /**
    * @override
-   * @export
    * @return {function(new: REQUEST, ...)}
    */
   getRequestMessageCtor() {
     return this.requestType;
   }
 
-  /**
-   * @override
-   * @export
-   */
+  /** @override */
   getResponseDeserializeFn() {
     return this.responseDeserializeFn;
   }
 
-  /**
-   * @override
-   * @export
-   */
+  /** @override */
   getRequestSerializeFn() {
     return this.requestSerializeFn;
   }

--- a/packages/grpc-web/externs.js
+++ b/packages/grpc-web/externs.js
@@ -32,11 +32,3 @@ module.UnaryResponse.prototype.getResponseMessage = function() {};
 module.UnaryResponse.prototype.getMetadata = function() {};
 module.UnaryResponse.prototype.getMethodDescriptor = function() {};
 module.UnaryResponse.prototype.getStatus = function() {};
-
-module.MethodDescriptor = function() {};
-module.MethodDescriptor.getName = function() {};
-module.MethodDescriptor.getMethodType = function() {};
-module.MethodDescriptor.getResponseMessageCtor = function() {};
-module.MethodDescriptor.getRequestMessageCtor = function() {};
-module.MethodDescriptor.getResponseDeserializeFn = function() {};
-module.MethodDescriptor.getRequestSerializeFn = function() {};


### PR DESCRIPTION
Reverts grpc/grpc-web#1160

Unfortunately i have to rollback this PR because after merging this change it's causing some non-trivial code size increases for some Google products..

I think maybe there are some ways to expose these APIs ONLY for Github. But I'm not totally sure yet. Ideas are welcome too.. 😃

@tomferreira FYI.. Apologize for the inconveniences!