### PR TITLE
Add Github Actions (workflows) for building grpc-web protoc plugins (Linux, MacOS, and Windows)

### DIFF
--- a/.github/workflows/make-plugin-linux.yml
+++ b/.github/workflows/make-plugin-linux.yml
@@ -1,0 +1,32 @@
+name: Make Linux Plugin
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: 'Version number'
+        required: true
+        default: '1.x.x'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build plugin docker image
+      run: docker-compose build prereqs protoc-plugin
+    - name: Copy binary from Docker image
+      run: |
+        docker cp $(docker create grpcweb/protoc-plugin):/github/grpc-web/javascript/net/grpc/web/generator/protoc-gen-grpc-web \
+          ./protoc-gen-grpc-web-${{ github.event.inputs.version_number }}-linux-x86_64
+    - name: gen sha256
+      run: |
+        openssl dgst -sha256 -r -out protoc-gen-grpc-web-${{ github.event.inputs.version_number }}-linux-x86_64.sha256 \
+          protoc-gen-grpc-web-${{ github.event.inputs.version_number }}-linux-x86_64
+    - name: verify sha256
+      run: sha256sum -c protoc-gen-grpc-web-${{ github.event.inputs.version_number }}-linux-x86_64.sha256
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: plugin
+        path: protoc-gen-grpc-web*

--- a/.github/workflows/make-plugin-mac-os.yml
+++ b/.github/workflows/make-plugin-mac-os.yml
@@ -1,0 +1,48 @@
+name: Make MacOS Plugin
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: 'Version number'
+        required: true
+        default: '1.x.x'
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install build utils
+      run: brew install coreutils automake
+    - name: Checkout protobuf code
+      run: |
+        ./scripts/init_submodules.sh
+    # Protobuf build instructions from:
+    # https://github.com/protocolbuffers/protobuf/blob/master/src/README.md
+    - name: Build protobuf (configure & make)
+      run: |
+        cd ./third_party/protobuf
+        ./autogen.sh
+        ./configure
+        make -j$(nproc)
+        make install
+    - name: Remove dynamite dependencies (similar to `-static` on linux)
+      run: rm /usr/local/lib/libproto*.dylib
+    - name: make
+      run: make clean && make plugin
+    - name: move
+      run: |
+        mv javascript/net/grpc/web/generator/protoc-gen-grpc-web \
+          ./protoc-gen-grpc-web-${{ github.event.inputs.version_number }}-darwin-x86_64
+    - name: gen sha256
+      run: |
+        openssl dgst -sha256 -r -out protoc-gen-grpc-web-${{ github.event.inputs.version_number }}-darwin-x86_64.sha256 \
+          protoc-gen-grpc-web-${{ github.event.inputs.version_number }}-darwin-x86_64
+    - name: verify sha256
+      run: sha256sum -c protoc-gen-grpc-web-${{ github.event.inputs.version_number }}-darwin-x86_64.sha256
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: plugin
+        path: protoc-gen-grpc-web*

--- a/.github/workflows/make-plugin-windows.yml
+++ b/.github/workflows/make-plugin-windows.yml
@@ -1,0 +1,37 @@
+name: Make Windows Plugin
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: 'Version number'
+        required: true
+        default: '1.x.x'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Print Bazel version
+      run: |
+        bazel version
+    - name: build
+      run: bazel build javascript/net/grpc/web/generator:protoc-gen-grpc-web
+    - name: move
+      run: |
+        mv bazel-bin/javascript/net/grpc/web/generator/protoc-gen-grpc-web.exe \
+          ./protoc-gen-grpc-web-${{ github.event.inputs.version_number }}-windows-x86_64.exe
+      shell: bash
+    - name: gen sha256
+      run: |
+        openssl dgst -sha256 -r -out protoc-gen-grpc-web-${{ github.event.inputs.version_number }}-windows-x86_64.exe.sha256 \
+          protoc-gen-grpc-web-${{ github.event.inputs.version_number }}-windows-x86_64.exe
+      shell: bash
+    # TODO: Check sha256 (sha256sum not available for now. )
+    #- name: verify sha256
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: plugin
+        path: protoc-gen-grpc-web*

--- a/net/grpc/gateway/docker/protoc_plugin/Dockerfile
+++ b/net/grpc/gateway/docker/protoc_plugin/Dockerfile
@@ -30,7 +30,11 @@ RUN apt-get -qq update && apt-get -qq install -y \
 WORKDIR /github/grpc-web
 
 RUN cd ./third_party/protobuf && \
-  ./autogen.sh && ./configure && make && make install && ldconfig
+  ./autogen.sh && \
+  ./configure && \
+  make && \
+  make install && \
+  ldconfig
 
 RUN cd ./javascript/net/grpc/web/generator && \
   make protoc-gen-grpc-web


### PR DESCRIPTION
# Summary

For Linux, MacOS, and Windows:
* Added new Github Actions (Workflow) for building the `protoc-gen-grpc-web` plugin to be used for releases.
* Workflow can be manually triggered with a `version_number` param (part of binary name)
* sha256 checksum are also generated and verified (except Windows)
* Plugin binary and sha256 are uploaded for manual download

## Platform specifics

* Linux - plugin built using Docker
* MacOS - plugin built using Makefile
  * Protobuf installed using `make install` from git submodule
* Windows - plugin built using Bazel