### PR TITLE
Make the static flag overridable

### DIFF
--- a/javascript/net/grpc/web/generator/Makefile
+++ b/javascript/net/grpc/web/generator/Makefile
@@ -18,12 +18,15 @@ CXXFLAGS += -std=c++11
 LDFLAGS += -L/usr/local/lib -lprotoc -lprotobuf -lpthread -ldl
 PREFIX ?= /usr/local
 MIN_MACOS_VERSION := 10.7 # Supports OS X Lion
+STATIC ?= yes
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
   CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=$(MIN_MACOS_VERSION)
 else ifeq ($(UNAME_S),Linux)
-  LDFLAGS += -static
+  ifeq ($(STATIC),yes)
+    LDFLAGS += -static
+  endif
 endif
 
 all: protoc-gen-grpc-web


### PR DESCRIPTION
Forcing the `-static` flag breaks nixpkgs builds so it's important to be able to disable it
