### PR TITLE
Upgrade protobuf and grpc deps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,19 +13,19 @@ http_archive(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "77ad26d3f65222fd96ccc18b055632b0bfedf295cb748b712a98ba1ac0b704b2",
-    strip_prefix = "protobuf-3.17.3",
+    sha256 = "ba0650be1b169d24908eeddbe6107f011d8df0da5b1a5a4449a913b10e578faf",
+    strip_prefix = "protobuf-3.19.4",
     urls = [
-        "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-all-3.17.3.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protobuf-all-3.19.4.tar.gz",
     ],
 )
 
 http_archive(
     name = "com_github_grpc_grpc",
-    sha256 = "43feda4d7ce2892400d5a0cbccecc5b1790f3253244a171360018d84c2949fb7",
-    strip_prefix = "grpc-1.33.2",
+    sha256 = "de2d3168e77e5ffb27758b07e87f6066fd0d8087fe272f278771e7780e6aaacb",
+    strip_prefix = "grpc-1.44.0",
     urls = [
-        "https://github.com/grpc/grpc/archive/v1.33.2.zip",
+        "https://github.com/grpc/grpc/archive/v1.44.0.zip",
     ],
 )
 

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -22,7 +22,7 @@
 FROM buildpack-deps:stretch AS prepare
 
 ARG BUILDIFIER_VERSION=1.0.0
-ARG PROTOBUF_VERSION=3.17.3
+ARG PROTOBUF_VERSION=3.19.4
 
 RUN apt-get -qq update && apt-get -qq install -y curl unzip
 


### PR DESCRIPTION
Without the upgrade of gRPC, I cannot build grpc-web with bazel 5.0.0; with this patch it works.

Error from using bazel 5 with old grpc dep on ubuntu 20.04:

```
Starting local Bazel server and connecting to it...                                                                                                           
Loading:                                                                                                                                                      
Loading: 0 packages loaded                                                                                                                                    
Loading: 0 packages loaded                                                                                                                                    
Loading: 0 packages loaded                                                                                                                                    
Loading: 0 packages loaded                                                                                                                                    
Analyzing: 6 targets (2 packages loaded, 0 targets configured)                                                                                                
ERROR: Traceback (most recent call last):                                                                                                                     
        File "/root/.cache/bazel/_bazel_root/f13c4d1ddc0c0b52d282683ced3f4e3e/external/build_bazel_rules_apple/apple/internal/testing/ios_rules.bzl", line 62,
 column 61, in <toplevel>                                                                                                                                     
                ios_ui_test_bundle = rule_factory.create_apple_bundling_rule(                                                                                 
        File "/root/.cache/bazel/_bazel_root/f13c4d1ddc0c0b52d282683ced3f4e3e/external/build_bazel_rules_apple/apple/internal/rule_factory.bzl", line 904, col
umn 55, in _create_apple_bundling_rule                                                                                                                        
                rule_attrs.append(_common_binary_linking_attrs(rule_descriptor))                                                                              
        File "/root/.cache/bazel/_bazel_root/f13c4d1ddc0c0b52d282683ced3f4e3e/external/build_bazel_rules_apple/apple/internal/rule_factory.bzl", line 218, col
umn 21, in _common_binary_linking_attrs                                                                                                                       
                apple_common.objc_proto_aspect,                                                                                                               
Error: 'apple_common' value has no field or method 'objc_proto_aspect'                                                                                        
INFO: Repository go_sdk instantiated at:                                                                                                                      
  /deps/grpc-web/WORKSPACE:38:16: in <toplevel>                                                                                                               
  /root/.cache/bazel/_bazel_root/f13c4d1ddc0c0b52d282683ced3f4e3e/external/com_github_grpc_grpc/bazel/grpc_extra_deps.bzl:36:27: in grpc_extra_deps           
  /root/.cache/bazel/_bazel_root/f13c4d1ddc0c0b52d282683ced3f4e3e/external/io_bazel_rules_go/go/toolchain/toolchains.bzl:379:28: in go_register_toolchains    
  /root/.cache/bazel/_bazel_root/f13c4d1ddc0c0b52d282683ced3f4e3e/external/io_bazel_rules_go/go/private/sdk.bzl:65:21: in go_download_sdk                     
Repository rule _go_download_sdk defined at:                                                                                                                  
  /root/.cache/bazel/_bazel_root/f13c4d1ddc0c0b52d282683ced3f4e3e/external/io_bazel_rules_go/go/private/sdk.bzl:53:35: in <toplevel>                          
INFO: Repository rules_python instantiated at:                                                                                                                
  /deps/grpc-web/WORKSPACE:34:10: in <toplevel>                                
  /root/.cache/bazel/_bazel_root/f13c4d1ddc0c0b52d282683ced3f4e3e/external/com_github_grpc_grpc/bazel/grpc_deps.bzl:348:21: in grpc_deps                      
  /root/.cache/bazel/_bazel_root/f13c4d1ddc0c0b52d282683ced3f4e3e/external/com_github_grpc_grpc/bazel/grpc_python_deps.bzl:44:21: in grpc_python_deps         
Repository rule http_archive defined at:                                                                                                                      
  /root/.cache/bazel/_bazel_root/f13c4d1ddc0c0b52d282683ced3f4e3e/external/bazel_tools/tools/build_defs/repo/http.bzl:364:31: in <toplevel>
ERROR: /deps/grpc-web/net/grpc/gateway/examples/echo/BUILD.bazel:21:16: error loading package '@com_github_grpc_grpc//src/compiler': at /root/.cache/bazel/_ba
zel_root/f13c4d1ddc0c0b52d282683ced3f4e3e/external/com_github_grpc_grpc/bazel/grpc_build_system.bzl:28:6: at /root/.cache/bazel/_bazel_root/f13c4d1ddc0c0b52d2
82683ced3f4e3e/external/build_bazel_rules_apple/apple/ios.bzl:22:5: initialization of module 'apple/internal/testing/ios_rules.bzl' failed and referenced by '
//net/grpc/gateway/examples/echo:_echo_cc_grpc_grpc_codegen'                                                                                                  
ERROR: Analysis of target '//net/grpc/gateway/examples/echo:_echo_cc_grpc_grpc_codegen' failed; build aborted: Analysis failed
INFO: Elapsed time: 5.618s                                                                                                                                    
INFO: 0 processes.                                                                                                                                            
FAILED: Build did NOT complete successfully (30 packages loaded, 6 targets configured)                                                                        
FAILED: Build did NOT complete successfully (30 packages loaded, 6 targets configured)            
```