### PR TITLE
Move node-client.js to avoid confusion.

### DIFF
--- a/net/grpc/gateway/examples/helloworld/debugging/node-client.js
+++ b/net/grpc/gateway/examples/helloworld/debugging/node-client.js
@@ -1,3 +1,6 @@
+// NOTE: This client is used for debugging the node gRPC server WITHOUT the
+// Envoy proxy. It does not use the gRPC-Web protocol.
+
 var PROTO_PATH = __dirname + '/helloworld.proto';
 
 var async = require('async');


### PR DESCRIPTION
The node-client.js is used to test the node server directly (without using Envoy proxy). Moving it to debugging/ folder to avoid confusion. :)

Fixes https://github.com/grpc/grpc-web/issues/1177