### PR TITLE
GrpcWebClientReadableStream: keep falsy data

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -123,18 +123,18 @@ class GrpcWebClientBase {
       let unaryStatus;
       let unaryMsg;
       GrpcWebClientBase.setCallback_(
-          stream, (error, response, status, metadata, unaryEndOfStream) => {
+          stream, (error, response, status, metadata, unaryResponseReceived) => {
             if (error) {
               reject(error);
+            } else if (unaryResponseReceived) {
+              unaryMsg = response;
             } else if (status) {
               unaryStatus = status;
             } else if (metadata) {
               unaryMetadata = metadata;
-            } else if (unaryEndOfStream) {
+            } else {
               resolve(request.getMethodDescriptor().createUnaryResponse(
                   unaryMsg, unaryMetadata, unaryStatus));
-            } else {
-              unaryMsg = response;
             }
           }, true);
     });
@@ -224,7 +224,14 @@ class GrpcWebClientBase {
    * @param {!ClientReadableStream<RESPONSE>} stream
    * @param {function(?RpcError, ?RESPONSE, ?Status=, ?Object<string, string>=, ?boolean)|
    *     function(?RpcError,?RESPONSE)} callback
-   * @param {boolean} useUnaryResponse
+   * @param {boolean} useUnaryResponse Pass true to have the client make
+   * multiple calls to the callback, using (error, response, status,
+   * metadata, unaryResponseReceived) arguments. One of error, status,
+   * metadata, or unaryResponseReceived will be truthy to indicate which piece
+   * of information the client is providing in that call. After the stream
+   * ends, it will call the callback an additional time with all falsy
+   * arguments. Pass false to have the client make one call to the callback
+   * using (error, response) arguments.
    */
   static setCallback_(stream, callback, useUnaryResponse) {
     let isResponseReceived = false;
@@ -272,11 +279,11 @@ class GrpcWebClientBase {
             message: 'Incomplete response',
           });
         } else {
-          callback(null, responseReceived);
+          callback(null, responseReceived, null, null, /* unaryResponseReceived= */ true);
         }
       }
       if (useUnaryResponse) {
-        callback(null, null, null, null, /* unaryEndOfStream= */ true);
+        callback(null, null);
       }
     });
   }

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -123,18 +123,18 @@ class GrpcWebClientBase {
       let unaryStatus;
       let unaryMsg;
       GrpcWebClientBase.setCallback_(
-          stream, (error, response, status, metadata) => {
+          stream, (error, response, status, metadata, unaryEndOfStream) => {
             if (error) {
               reject(error);
-            } else if (response) {
-              unaryMsg = response;
             } else if (status) {
               unaryStatus = status;
             } else if (metadata) {
               unaryMetadata = metadata;
-            } else {
+            } else if (unaryEndOfStream) {
               resolve(request.getMethodDescriptor().createUnaryResponse(
                   unaryMsg, unaryMetadata, unaryStatus));
+            } else {
+              unaryMsg = response;
             }
           }, true);
     });
@@ -222,7 +222,7 @@ class GrpcWebClientBase {
    * @static
    * @template RESPONSE
    * @param {!ClientReadableStream<RESPONSE>} stream
-   * @param {function(?RpcError, ?RESPONSE, ?Status=, ?Object<string, string>=)|
+   * @param {function(?RpcError, ?RESPONSE, ?Status=, ?Object<string, string>=, ?boolean)|
    *     function(?RpcError,?RESPONSE)} callback
    * @param {boolean} useUnaryResponse
    */
@@ -276,7 +276,7 @@ class GrpcWebClientBase {
         }
       }
       if (useUnaryResponse) {
-        callback(null, null);  // trigger unaryResponse
+        callback(null, null, null, null, /* unaryEndOfStream= */ true);
       }
     });
   }

--- a/javascript/net/grpc/web/grpcwebclientbase_test.js
+++ b/javascript/net/grpc/web/grpcwebclientbase_test.js
@@ -102,6 +102,28 @@ testSuite({
     assertElementsEquals(DEFAULT_UNARY_HEADER_VALUES, Object.values(headers));
   },
 
+  async testRpcResponseThenableCall() {
+    const xhr = new XhrIo();
+    const client = new GrpcWebClientBase(/* options= */ {}, xhr);
+    const methodDescriptor = createMethodDescriptor((bytes) => {
+      assertElementsEquals(DEFAULT_RPC_RESPONSE_DATA, [].slice.call(bytes));
+      return new MockReply('value');
+    });
+
+    const responsePromise = client.thenableCall(
+      'url', new MockRequest(), /* metadata= */ {}, methodDescriptor);
+    xhr.simulatePartialResponse(
+        googCrypt.encodeByteArray(new Uint8Array(DEFAULT_RPC_RESPONSE)),
+        DEFAULT_RESPONSE_HEADERS);
+    xhr.simulateReadyStateChange(ReadyState.COMPLETE);
+    const response = await responsePromise;
+
+    assertEquals('value', response.data);
+    const headers = /** @type {!Object} */ (xhr.getLastRequestHeaders());
+    assertElementsEquals(DEFAULT_UNARY_HEADERS, Object.keys(headers));
+    assertElementsEquals(DEFAULT_UNARY_HEADER_VALUES, Object.values(headers));
+  },
+
   async testRpcFalsyResponseThenableCall_ForNonProtobufDescriptor() {
     const xhr = new XhrIo();
     const client = new GrpcWebClientBase(/* options= */ {}, xhr);

--- a/javascript/net/grpc/web/grpcwebclientbase_test.js
+++ b/javascript/net/grpc/web/grpcwebclientbase_test.js
@@ -102,6 +102,28 @@ testSuite({
     assertElementsEquals(DEFAULT_UNARY_HEADER_VALUES, Object.values(headers));
   },
 
+  async testRpcFalsyResponseThenableCall_ForNonProtobufDescriptor() {
+    const xhr = new XhrIo();
+    const client = new GrpcWebClientBase(/* options= */ {}, xhr);
+    const methodDescriptor = createMethodDescriptor((bytes) => {
+      assertElementsEquals(DEFAULT_RPC_RESPONSE_DATA, [].slice.call(bytes));
+      return 0;
+    });
+
+    const responsePromise = client.thenableCall(
+      'url', new MockRequest(), /* metadata= */ {}, methodDescriptor);
+    xhr.simulatePartialResponse(
+        googCrypt.encodeByteArray(new Uint8Array(DEFAULT_RPC_RESPONSE)),
+        DEFAULT_RESPONSE_HEADERS);
+    xhr.simulateReadyStateChange(ReadyState.COMPLETE);
+    const response = await responsePromise;
+
+    assertEquals(0, response);
+    const headers = /** @type {!Object} */ (xhr.getLastRequestHeaders());
+    assertElementsEquals(DEFAULT_UNARY_HEADERS, Object.keys(headers));
+    assertElementsEquals(DEFAULT_UNARY_HEADER_VALUES, Object.values(headers));
+  },
+
   async testDeadline() {
     const xhr = new XhrIo();
     const client = new GrpcWebClientBase(/* options= */ {}, xhr);

--- a/javascript/net/grpc/web/grpcwebclientbase_test.js
+++ b/javascript/net/grpc/web/grpcwebclientbase_test.js
@@ -75,6 +75,33 @@ testSuite({
     assertElementsEquals(DEFAULT_UNARY_HEADER_VALUES, Object.values(headers));
   },
 
+  async testRpcFalsyResponse_ForNonProtobufDescriptor() {
+    const xhr = new XhrIo();
+    const client = new GrpcWebClientBase(/* options= */ {}, xhr);
+    const methodDescriptor = createMethodDescriptor((bytes) => {
+      assertElementsEquals(DEFAULT_RPC_RESPONSE_DATA, [].slice.call(bytes));
+      return 0;
+    });
+
+    const response = await new Promise((resolve, reject) => {
+      client.rpcCall(
+          'url', new MockRequest(), /* metadata= */ {}, methodDescriptor,
+          (error, response) => {
+            assertNull(error);
+            resolve(response);
+          });
+      xhr.simulatePartialResponse(
+          googCrypt.encodeByteArray(new Uint8Array(DEFAULT_RPC_RESPONSE)),
+          DEFAULT_RESPONSE_HEADERS);
+      xhr.simulateReadyStateChange(ReadyState.COMPLETE);
+    });
+
+    assertEquals(0, response);
+    const headers = /** @type {!Object} */ (xhr.getLastRequestHeaders());
+    assertElementsEquals(DEFAULT_UNARY_HEADERS, Object.keys(headers));
+    assertElementsEquals(DEFAULT_UNARY_HEADER_VALUES, Object.values(headers));
+  },
+
   async testDeadline() {
     const xhr = new XhrIo();
     const client = new GrpcWebClientBase(/* options= */ {}, xhr);

--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -170,16 +170,18 @@ class GrpcWebClientReadableStream {
           if (FrameType.DATA in messages[i]) {
             const data = messages[i][FrameType.DATA];
             if (data) {
+              let isResponseDeserialized = false;
               let response;
               try {
                 response = self.responseDeserializeFn_(data);
+                isResponseDeserialized = true;
               } catch (err) {
                 self.handleError_(new RpcError(
                     StatusCode.INTERNAL,
                     `Error when deserializing response data; error: ${err}` +
                         `, response: ${response}`));
               }
-              if (response) {
+              if (isResponseDeserialized) {
                 self.sendDataCallbacks_(response);
               }
             }


### PR DESCRIPTION
cross reference https://github.com/grpc/grpc-web/pull/1025

When using a different codec where primitive values are allowed (we use CBOR), the current implementation omits calling the `data` listeners on falsy values, such as `0` and `null`. But we'd like to have them.

Is there anything else that relies on the current behavior that omits these values?

---

Discussion of changes in `GrpcWebClientBase`:

Current implementation uses `setCallback_` in a special "useUnaryResponse" mode. In this mode, additional calls are made to the callback with `status` and `metadata` parameters, then a final time with both `error` and `response` set to `null`.

In order to support falsy and even null message, this changes the final callback call to pass `true` to a new explicit `trigger` parameter. `callback(null, null)` now means "no error, and the response was null" (and similar for other falsy responses).

`setCallback_` is private, and the only public wrapper does not allow the "useUnaryResponse" mode, so it should be safe to make this change.