### PR TITLE
[TM-2261] Update PromiseClient generation to be cancelable

### DIFF
--- a/javascript/net/grpc/web/abstractclientbase.js
+++ b/javascript/net/grpc/web/abstractclientbase.js
@@ -65,10 +65,11 @@ const AbstractClientBase = class {
    * @param {!MethodDescriptor<REQUEST, RESPONSE>|
    *     !AbstractClientBase.MethodInfo<REQUEST,RESPONSE>}
    *   methodDescriptor Information of this RPC method
+   * @param {?AbortSignal} abortSignal Signal to abort the call
    * @return {!IThenable <!RESPONSE>}
    *   A promise that resolves to the response message
    */
-  thenableCall(method, requestMessage, metadata, methodDescriptor) {}
+  thenableCall(method, requestMessage, metadata, methodDescriptor, abortSignal) {}
 
   /**
    * @abstract

--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -696,7 +696,8 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Indent();
           printer->Print(vars,
                          "request: $input_type$,\n"
-                         "metadata: grpcWeb.Metadata | null): "
+                         "metadata: grpcWeb.Metadata | null,\n"
+                         "abortSignal: AbortSignal | null): "
                          "$promise$<$output_type$>;\n\n");
           printer->Outdent();
 
@@ -788,7 +789,8 @@ void PrintGrpcWebDtsClientClass(Printer* printer, const FileDescriptor* file,
             printer->Indent();
             printer->Print(vars,
                            "request: $input_type$,\n"
-                           "metadata?: grpcWeb.Metadata\n");
+                           "metadata?: grpcWeb.Metadata,\n"
+                           "abortSignal?: AbortSignal\n");
             printer->Outdent();
             printer->Print(vars, "): $promise$<$output_type$>;\n\n");
           } else {
@@ -1259,6 +1261,7 @@ void PrintPromiseUnaryCall(Printer* printer, std::map<string, string> vars) {
                  " *     request proto\n"
                  " * @param {?Object<string, string>} metadata User defined\n"
                  " *     call metadata\n"
+                 " * @param {?AbortSignal} abortSignal Signal to abort the call\n"
                  " * @return {!$promise$<!proto.$out$>}\n"
                  " *     Promise that resolves to the response\n"
                  " */\n"
@@ -1266,7 +1269,7 @@ void PrintPromiseUnaryCall(Printer* printer, std::map<string, string> vars) {
                  ".$js_method_name$ =\n");
   printer->Indent();
   printer->Print(vars,
-                 "  function(request, metadata) {\n"
+                 "  function(request, metadata, abortSignal) {\n"
                  "return this.client_.unaryCall(this.hostname_ +\n");
   printer->Indent();
   printer->Indent();
@@ -1280,7 +1283,8 @@ void PrintPromiseUnaryCall(Printer* printer, std::map<string, string> vars) {
   printer->Print(vars,
                  "request,\n"
                  "metadata || {},\n"
-                 "$method_descriptor$);\n");
+                 "$method_descriptor$,\n"
+                 "abortSignal);\n");
   printer->Outdent();
   printer->Outdent();
   printer->Outdent();
@@ -1702,7 +1706,7 @@ class GrpcCodeGenerator : public CodeGenerator {
         break;
       case ImportStyle::COMMONJS:
         printer.Print(vars, "const grpc = {};\n");
-        printer.Print(vars, "grpc.web = require('grpc-web');\n\n");
+        printer.Print(vars, "grpc.web = require('@safetyculture/grpc-web');\n\n");
         PrintCommonJsMessagesDeps(&printer, file);
         break;
       case ImportStyle::TYPESCRIPT:

--- a/javascript/net/grpc/web/grpc_generator.cc
+++ b/javascript/net/grpc/web/grpc_generator.cc
@@ -599,7 +599,7 @@ void PrintCommonJsMessagesDeps(Printer* printer, const FileDescriptor* file) {
 void PrintES6Imports(Printer* printer, const FileDescriptor* file) {
   std::map<string, string> vars;
 
-  printer->Print("import * as grpcWeb from 'grpc-web';\n\n");
+  printer->Print("import * as grpcWeb from '@safetyculture/grpc-web';\n\n");
 
   std::set<string> imports;
   for (const Descriptor* message : GetAllMessages(file)) {

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -112,7 +112,7 @@ class GrpcWebClientBase {
    * @override
    * @export
    */
-  thenableCall(method, requestMessage, metadata, methodDescriptor) {
+  thenableCall(method, requestMessage, metadata, methodDescriptor, abortSignal) {
     methodDescriptor = AbstractClientBase.ensureMethodDescriptor(
         method, requestMessage, MethodType.UNARY, methodDescriptor);
     var hostname = AbstractClientBase.getHostname(method, methodDescriptor);
@@ -136,6 +136,14 @@ class GrpcWebClientBase {
                   unaryMsg, unaryMetadata, unaryStatus));
             }
           }, true);
+      if (abortSignal) {
+        abortSignal.addEventListener("abort", () => {
+          stream.cancel();
+        });
+        if (abortSignal.aborted) {
+          stream.cancel();
+        }
+      }
     });
     var invoker = GrpcWebClientBase.runInterceptors_(
         initialInvoker, this.unaryInterceptors_);
@@ -152,12 +160,13 @@ class GrpcWebClientBase {
    * @param {!MethodDescriptor<REQUEST, RESPONSE>|
    *     !AbstractClientBase.MethodInfo<REQUEST,RESPONSE>}
    *   methodDescriptor Information of this RPC method
+   * @param {?AbortSignal} abortSignal Signal to abort the call
    * @return {!Promise<RESPONSE>}
    * @template REQUEST, RESPONSE
    */
-  unaryCall(method, requestMessage, metadata, methodDescriptor) {
+  unaryCall(method, requestMessage, metadata, methodDescriptor, abortSignal) {
     return /** @type {!Promise<RESPONSE>}*/ (
-        this.thenableCall(method, requestMessage, metadata, methodDescriptor));
+        this.thenableCall(method, requestMessage, metadata, methodDescriptor, abortSignal));
   }
 
   /**

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -15,7 +15,8 @@ declare module "grpc-web" {
       method: string,
       request: REQ,
       metadata: Metadata,
-      methodDescriptor: MethodDescriptor<REQ, RESP>
+      methodDescriptor: MethodDescriptor<REQ, RESP>,
+      abortSignal: AbortSignal
     ): Promise<RESP>;
 
     rpcCall<REQ, RESP> (
@@ -56,7 +57,7 @@ declare module "grpc-web" {
                     callback: (response: RESP) => void): void;
     removeListener (eventType: "end",
                     callback: () => void): void;
-                    
+
     cancel (): void;
   }
 
@@ -87,14 +88,14 @@ declare module "grpc-web" {
                   metadata: Metadata,
                   callOptions: CallOptions): UnaryResponse<REQ, RESP>;
   }
-  
+
   export class Request<REQ, RESP> {
     getRequestMessage(): REQ;
     getMethodDescriptor(): MethodDescriptor<REQ, RESP>;
     getMetadata(): Metadata;
     getCallOptions(): CallOptions;
   }
-  
+
   export class UnaryResponse<REQ, RESP> {
     getResponseMessage(): RESP;
     getMetadata(): Metadata;

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -1,4 +1,4 @@
-declare module "grpc-web" {
+declare module "@safetyculture/grpc-web" {
 
   export interface Metadata { [s: string]: string; }
 

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "grpc-web",
+  "name": "@safetyculture/grpc-web",
   "version": "1.2.1",
   "author": "Google Inc.",
   "description": "gRPC-Web Client Runtime Library",
   "homepage": "https://grpc.io/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/grpc/grpc-web.git"
+    "url": "https://github.com/SafetyCulture/grpc-web.git"
   },
   "bugs": "https://github.com/grpc/grpc-web/issues",
   "files": [

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safetyculture/grpc-web",
-  "version": "1.2.1",
+  "version": "1.2.1-pre.2",
   "author": "Google Inc.",
   "description": "gRPC-Web Client Runtime Library",
   "homepage": "https://grpc.io/",

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safetyculture/grpc-web",
-  "version": "1.2.1-pre.4",
+  "version": "1.2.2",
   "author": "Google Inc.",
   "description": "gRPC-Web Client Runtime Library",
   "homepage": "https://grpc.io/",

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safetyculture/grpc-web",
-  "version": "1.2.1-pre.2",
+  "version": "1.2.1-pre.4",
   "author": "Google Inc.",
   "description": "gRPC-Web Client Runtime Library",
   "homepage": "https://grpc.io/",


### PR DESCRIPTION
This PR updates the way `PromiseClient` are generated to include a new `abortSignal` parameter to the calls so that they can be canceled.

The code was tested in a branch and confirmed to work.