### PR TITLE
Add abortSignal to unaryCall

### DIFF
--- a/javascript/net/grpc/web/abstractclientbase.js
+++ b/javascript/net/grpc/web/abstractclientbase.js
@@ -62,10 +62,11 @@ const AbstractClientBase = class {
    * @param {!Object<string, string>} metadata User defined call metadata
    * @param {!MethodDescriptor<REQUEST, RESPONSE>}
    *   methodDescriptor Information of this RPC method
+   * @param {?AbortSignal} abortSignal Signal to abort the call
    * @return {!IThenable<RESPONSE>}
    *   A promise that resolves to the response message
    */
-  thenableCall(method, requestMessage, metadata, methodDescriptor) {}
+  thenableCall(method, requestMessage, metadata, methodDescriptor, abortSignal) {}
 
   /**
    * @abstract

--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -651,7 +651,8 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Indent();
           printer->Print(vars,
                          "request: $input_type$,\n"
-                         "metadata: grpcWeb.Metadata | null): "
+                         "metadata: grpcWeb.Metadata | null,\n"
+                         "abortSignal: AbortSignal | null): "
                          "$promise$<$output_type$>;\n\n");
           printer->Outdent();
 
@@ -742,7 +743,8 @@ void PrintGrpcWebDtsClientClass(Printer* printer, const FileDescriptor* file,
             printer->Indent();
             printer->Print(vars,
                            "request: $input_type$,\n"
-                           "metadata?: grpcWeb.Metadata\n");
+                           "metadata?: grpcWeb.Metadata,\n"
+                           "abortSignal?: AbortSignal\n");
             printer->Outdent();
             printer->Print(vars, "): $promise$<$output_type$>;\n\n");
           } else {
@@ -1168,6 +1170,7 @@ void PrintPromiseUnaryCall(Printer* printer, std::map<string, string> vars) {
                  " *     request proto\n"
                  " * @param {?Object<string, string>=} metadata User defined\n"
                  " *     call metadata\n"
+                 " * @param {?AbortSignal} abortSignal Signal to abort the call\n"
                  " * @return {!$promise$<!proto.$out$>}\n"
                  " *     Promise that resolves to the response\n"
                  " */\n"
@@ -1175,7 +1178,7 @@ void PrintPromiseUnaryCall(Printer* printer, std::map<string, string> vars) {
                  ".$js_method_name$ =\n");
   printer->Indent();
   printer->Print(vars,
-                 "  function(request, metadata) {\n"
+                 "  function(request, metadata, abortSignal) {\n"
                  "return this.client_.unaryCall(this.hostname_ +\n");
   printer->Indent();
   printer->Indent();
@@ -1188,7 +1191,8 @@ void PrintPromiseUnaryCall(Printer* printer, std::map<string, string> vars) {
   printer->Print(vars,
                  "request,\n"
                  "metadata || {},\n"
-                 "$method_descriptor$);\n");
+                 "$method_descriptor$,\n"
+                 "abortSignal);\n");
   printer->Outdent();
   printer->Outdent();
   printer->Outdent();


### PR DESCRIPTION
The goal of this PR is to add an `abortSignal` parameter when making calls using the `PromiseClient`, which cancels the gRPC stream when the signal is aborted. 

There has already been interest in being able to cancel calls made using promises: https://github.com/grpc/grpc-web/issues/946