### PR TITLE
make sure envoy is pid 1

### DIFF
--- a/net/grpc/gateway/docker/envoy/Dockerfile
+++ b/net/grpc/gateway/docker/envoy/Dockerfile
@@ -16,4 +16,5 @@ FROM envoyproxy/envoy:v1.22.0
 
 COPY net/grpc/gateway/examples/echo/envoy.yaml /etc/envoy/envoy.yaml
 
-CMD /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l trace --log-path /tmp/envoy_info.log
+ENTRYPOINT [ "/usr/local/bin/envoy" ]
+CMD [ "-c /etc/envoy/envoy.yaml", "-l trace", "--log-path /tmp/envoy_info.log" ]


### PR DESCRIPTION
This ensures signals are handled properly so docker stop responds quickly and doesn't need to wait for time out (10s by default)

By default ENTRYPOINT passed as string (not an array) translates to `/bin/sh -c` followed by the value which means sh is pid 1, not envoy, and `docker stop` hangs for 10s.