### PR TITLE
Fix code and documentation to pass `deadline` metadata as a String.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ should be a Unix timestamp, in milliseconds.
 var deadline = new Date();
 deadline.setSeconds(deadline.getSeconds() + 1);
 
-client.sayHelloAfterDelay(request, {deadline: deadline.getTime()},
+client.sayHelloAfterDelay(request, {deadline: deadline.getTime().toString()},
   (err, response) => {
     // err will be populated if the RPC exceeds the deadline
     ...

--- a/javascript/net/grpc/web/grpcwebclientbase_test.js
+++ b/javascript/net/grpc/web/grpcwebclientbase_test.js
@@ -84,8 +84,8 @@ testSuite({
     deadline.setSeconds(deadline.getSeconds() + 1);
     await new Promise((resolve, reject) => {
       client.rpcCall(
-          'url', new MockRequest(), {'deadline': deadline}, methodDescriptor,
-          (error, response) => {
+          'url', new MockRequest(), {'deadline': deadline.getTime().toString()},
+          methodDescriptor, (error, response) => {
             assertNull(error);
             resolve();
           });

--- a/test/interop/interop_client.js
+++ b/test/interop/interop_client.js
@@ -52,8 +52,10 @@ function doEmptyUnary(done) {
 
 function doEmptyUnaryWithDeadline(done) {
   var testService = new TestServiceClient(SERVER_HOST, null, null);
-  const deadlineMs = 1000; // 1 second
-  testService.emptyCall(new Empty(), {deadline: Date.now() + deadlineMs},
+
+  const deadline = new Date();
+  deadline.setSeconds(deadline.getSeconds() + 1);
+  testService.emptyCall(new Empty(), {deadline: deadline.getTime().toString()},
     (err, response) => {
       assert.ifError(err);
       assert(response instanceof Empty);


### PR DESCRIPTION
- As Metadata is a <string, string> map per [Closure](https://github.com/grpc/grpc-web/blob/6b1d1e97a9a44e7f72b7b401964f9ffe1da27c7a/javascript/net/grpc/web/metadata.js#L11) and [TS](https://github.com/grpc/grpc-web/blob/6b1d1e97a9a44e7f72b7b401964f9ffe1da27c7a/packages/grpc-web/index.d.ts#L3) definition.

Fixes #1268 