### PR TITLE
Fix Enum with module in generated TS interface.

### DIFF
--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -335,7 +335,7 @@ string JSElementType(const FieldDescriptor* desc, const FileDescriptor* file) {
                               desc->enum_type()->file()->package());
         return StripPrefixString(enum_name, ".");
       }
-      return ModuleAlias(desc->enum_type()->file()->name()) +
+      return ModuleAlias(desc->enum_type()->file()->name()) + "." +
              StripPrefixString(desc->enum_type()->full_name(),
                                desc->enum_type()->file()->package());
 


### PR DESCRIPTION
Verified with the example in https://github.com/grpc/grpc-web/issues/1271

// enum.proto
```proto
syntax = "proto3";

enum DocEnum {
    DOC_ENUM_PDF = 0;
    DOC_ENUM_HTML = 1;
}
```

// test.proto
```proto
syntax = "proto3";

import "enum.proto";

package Test;

message HelloRequest {
    DocEnum doc = 1;
}
```

Generate:
```
protoc -I=. *.proto --js_out=import_style=commonjs,binary:. --grpc-web_out=import_style=typescript,mode=grpcwebtext:.
```

### Before
```
getDoc(): enum_pbDocEnum;
setDoc(value: enum_pbDocEnum): HelloRequest;
```

### After

```
getDoc(): enum_pb.DocEnum;
setDoc(value: enum_pb.DocEnum): HelloRequest;
```
---

Fixes https://github.com/grpc/grpc-web/issues/1271