### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-web",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "author": "Google Inc.",
   "description": "gRPC-Web Client Runtime Library",
   "homepage": "https://grpc.io/",


### PR DESCRIPTION
- Bumping minor version since we're releasing new binaries for ARM to support Apple Silicon (M1/M2) (powered by https://github.com/grpc/grpc-web/pull/1249) :)