### PR TITLE
Expose getName() in MethodDescriptor and fix TS definitions.

### DIFF
--- a/javascript/net/grpc/web/methoddescriptor.js
+++ b/javascript/net/grpc/web/methoddescriptor.js
@@ -74,6 +74,7 @@ const MethodDescriptor = class {
 
   /**
    * @override
+   * @export
    */
   getName() {
     return this.name;

--- a/packages/grpc-web/externs.js
+++ b/packages/grpc-web/externs.js
@@ -32,3 +32,6 @@ module.UnaryResponse.prototype.getResponseMessage = function() {};
 module.UnaryResponse.prototype.getMetadata = function() {};
 module.UnaryResponse.prototype.getMethodDescriptor = function() {};
 module.UnaryResponse.prototype.getStatus = function() {};
+
+module.MethodDescriptor = function() {};
+module.MethodDescriptor.getName = function() {};

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -75,18 +75,7 @@ declare module "grpc-web" {
                 responseType: new (...args: unknown[]) => RESP,
                 requestSerializeFn: any,
                 responseDeserializeFn: any);
-    createRequest(requestMessage: REQ,
-                  metadata?: Metadata,
-                  callOptions?: CallOptions): Request<REQ, RESP>;
-    createUnaryResponse(responseMessage: RESP,
-                        metadata?: Metadata,
-                        status?: Status): UnaryResponse<REQ, RESP>;
     getName(): string;
-    getMethodType(): string;
-    getRequestMessageCtor(): new (...args: unknown[]) => REQ;
-    getResponseMessageCtor(): new (...args: unknown[]) => RESP;
-    getRequestSerializeFn(): any;
-    getResponseDeserializeFn(): any;
   }
 
   export class Request<REQ, RESP> {


### PR DESCRIPTION
Backgrounds:

1. MethodDescriptor methods were exposed to match TS definition but later removed in #1199 due to internal code size increase.
2. `getName()` still seemed useful to some users per discussion in https://github.com/grpc/grpc-web/issues/1285

Hence we're re-exposing only the getName() method on MethodDescriptor, hoping it won't cause a code size issue internally and also address some user needs.