### PR TITLE
upgrade `google-protobuf` version to fix bundle size issues

### DIFF
--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -30,7 +30,7 @@
     "google-closure-compiler": "~20200224.0.0",
     "google-closure-deps": "~20210601.0.0",
     "google-closure-library": "~20210808.0.0",
-    "google-protobuf": "~3.14.0",
+    "google-protobuf": "~3.21.1",
     "gulp": "~4.0.2",
     "gulp-connect": "~5.7.0",
     "gulp-eval": "~1.0.0",


### PR DESCRIPTION
Based on this issue: https://github.com/protocolbuffers/protobuf-javascript/issues/124 on google-protobuf the new changes fixed and reduced the bundle size. So here we upgrade `google-protobuf` version to fix bundle size issues.

<img width="1213" alt="Screen Shot 1401-07-16 at 12 07 54" src="https://user-images.githubusercontent.com/6254009/194697284-86b34dbf-315f-457c-bcbb-fe5e81504221.png">
