### PR TITLE
GrpcWebClientBase: clean up !useUnaryResponse callback args

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -278,8 +278,10 @@ class GrpcWebClientBase {
             code: StatusCode.UNKNOWN,
             message: 'Incomplete response',
           });
-        } else {
+        } else if (useUnaryResponse) {
           callback(null, responseReceived, null, null, /* unaryResponseReceived= */ true);
+        } else {
+          callback(null, responseReceived);
         }
       }
       if (useUnaryResponse) {


### PR DESCRIPTION
from #1230, the public `rpcCall` allows users to provide a callback which is documented only to take 2 parameters. avoid passing the extra unaryResponseReceived flag in that case