### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 11.0.10

### DIFF
--- a/src/connector/pom.xml
+++ b/src/connector/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.41.v20210516</version>
+      <version>11.0.10</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.41.v20210516
- [CVE-2021-34428](https://www.oscs1024.com/hd/CVE-2021-34428)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.41.v20210516 to 11.0.10 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>