### PR TITLE
Fix TS callback error and response to be nullable

### DIFF
--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -660,8 +660,8 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Print(vars,
                          "request: $input_type$,\n"
                          "metadata: grpcWeb.Metadata | null,\n"
-                         "callback: (err: grpcWeb.RpcError,\n"
-                         "           response: $output_type$) => void): "
+                         "callback: (err: grpcWeb.RpcError | null,\n"
+                         "           response: $output_type$ | null) => void): "
                          "grpcWeb.ClientReadableStream<$output_type$>;\n\n");
           printer->Outdent();
 
@@ -670,8 +670,8 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Print(vars,
                          "request: $input_type$,\n"
                          "metadata: grpcWeb.Metadata | null,\n"
-                         "callback?: (err: grpcWeb.RpcError,\n"
-                         "           response: $output_type$) => void) {\n");
+                         "callback?: (err: grpcWeb.RpcError | null,\n"
+                         "            response: $output_type$ | null) => void) {\n");
           printer->Print(vars, "if (callback !== undefined) {\n");
           printer->Indent();
           printer->Print(vars, "return this.client_.rpcCall(\n");
@@ -751,8 +751,8 @@ void PrintGrpcWebDtsClientClass(Printer* printer, const FileDescriptor* file,
             printer->Print(vars,
                            "request: $input_type$,\n"
                            "metadata: grpcWeb.Metadata | undefined,\n"
-                           "callback: (err: grpcWeb.RpcError,\n"
-                           "           response: $output_type$) => void\n");
+                           "callback: (err: grpcWeb.RpcError | null,\n"
+                           "           response: $output_type$ | null) => void\n");
             printer->Outdent();
             printer->Print(vars,
                            "): grpcWeb.ClientReadableStream<$output_type$>;");

--- a/net/grpc/gateway/examples/echo/ts-example/client.ts
+++ b/net/grpc/gateway/examples/echo/ts-example/client.ts
@@ -55,7 +55,7 @@ class EchoApp {
     request.setMessage(msg);
     const call = this.echoService.echo(
         request, {'custom-header-1': 'value1'},
-        (err: grpcWeb.RpcError, response: EchoResponse) => {
+        (err: grpcWeb.RpcError | null, response: EchoResponse | null) => {
           if (err) {
             if (err.code !== grpcWeb.StatusCode.OK) {
               EchoApp.addRightMessage(
@@ -80,7 +80,7 @@ class EchoApp {
     const request = new EchoRequest();
     request.setMessage(msg);
     this.echoService.echoAbort(
-        request, {}, (err: grpcWeb.RpcError, response: EchoResponse) => {
+        request, {}, (err: grpcWeb.RpcError | null, response: EchoResponse | null) => {
           if (err && err.code !== grpcWeb.StatusCode.OK) {
             EchoApp.addRightMessage(
                 'Error code: ' + err.code + ' "' + decodeURI(err.message) +

--- a/packages/grpc-web/test/tsc-tests/client02.ts
+++ b/packages/grpc-web/test/tsc-tests/client02.ts
@@ -23,5 +23,5 @@ import {MyServiceClient} from './generated/Test02ServiceClientPb';
 const service = new MyServiceClient('http://mydummy.com', null, null);
 const req = new Integer();
 
-service.addOne(req, {}, (err: grpcWeb.RpcError, resp: Integer) => {
+service.addOne(req, {}, (err: grpcWeb.RpcError | null, resp: Integer | null) => {
 });

--- a/packages/grpc-web/test/tsc-tests/client05.ts
+++ b/packages/grpc-web/test/tsc-tests/client05.ts
@@ -30,8 +30,8 @@ req.setMessage('aaa');
 // this test tries to make sure that these types are as accurate as possible
 
 let call1 : grpcWeb.ClientReadableStream<EchoResponse> =
-  echoService.echo(req, {}, (err: grpcWeb.RpcError,
-                             response: EchoResponse) => {
+  echoService.echo(req, {}, (err: grpcWeb.RpcError | null,
+                             response: EchoResponse | null) => {
                              });
 
 call1


### PR DESCRIPTION
IMPORTANT: This will be a **BREAKING change** for some existing users, but hopefully in a good way because now the return type is more accurately reflecting the runtime behavior.

---

In reality, both error and response can be null.

JS Defintion:
https://github.com/grpc/grpc-web/blob/e49389873d887d15ab2870288f620aa2f15b3b85/javascript/net/grpc/web/abstractclientbase.js#L50-L51

Callsites:
https://github.com/grpc/grpc-web/blob/e49389873d887d15ab2870288f620aa2f15b3b85/javascript/net/grpc/web/grpcwebclientbase.js#L249

https://github.com/grpc/grpc-web/blob/e49389873d887d15ab2870288f620aa2f15b3b85/javascript/net/grpc/web/grpcwebclientbase.js#L284

---
Fixes #1309