### PR TITLE
Update ES6 imports with comment about corresponding proto import path.

### DIFF
--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -562,8 +562,10 @@ void PrintES6Imports(Printer* printer, const FileDescriptor* file) {
     }
     imports.insert(dep_filename);
     // We need to give each cross-file import an alias.
-    printer->Print("import * as $alias$ from '$dep_filename$_pb';\n", "alias",
-                   ModuleAlias(name), "dep_filename", dep_filename);
+    printer->Print("import * as $alias$ from '$dep_filename$_pb'; // proto import: \"$proto_import$\"\n",
+                   "alias", ModuleAlias(name),
+                   "dep_filename", dep_filename,
+                   "proto_import", name);
   }
   printer->Print("\n\n");
 }


### PR DESCRIPTION
I was observing a long import path in the generated code that doesn't work. Outputting the corresponding proto file is helpful for both diagnosing the issue and writing a wrapper for altering the import path to my satisfaction.

Before:

```javascript
import * as github_com_gonzojive_rules_ts_proto_example_prefix_greeting_pb from '../../../../../github.com/gonzojive/rules_ts_proto/example/prefix/greeting_pb';
```

After:

```javascript
import * as github_com_gonzojive_rules_ts_proto_example_prefix_greeting_pb from '../../../../../github.com/gonzojive/rules_ts_proto/example/prefix/greeting_pb'; // proto import: "github.com/gonzojive/rules_ts_proto/example/prefix/greeting.proto"
```