### PR TITLE
Update ES6 imports with comment about corresponding proto import path.

### DIFF
--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -555,15 +555,17 @@ void PrintES6Imports(Printer* printer, const FileDescriptor* file) {
 
   std::set<string> imports;
   for (const auto& entry : GetAllMessages(file)) {
-    const string& name = entry.second->file()->name();
-    string dep_filename = GetRootPath(file->name(), name) + StripProto(name);
+    const string& proto_filename = entry.second->file()->name();
+    string dep_filename = GetRootPath(file->name(), proto_filename) + StripProto(proto_filename);
     if (imports.find(dep_filename) != imports.end()) {
       continue;
     }
     imports.insert(dep_filename);
     // We need to give each cross-file import an alias.
-    printer->Print("import * as $alias$ from '$dep_filename$_pb';\n", "alias",
-                   ModuleAlias(name), "dep_filename", dep_filename);
+    printer->Print("import * as $alias$ from '$dep_filename$_pb'; // proto import: \"$proto_filename$\"\n",
+                   "alias", ModuleAlias(proto_filename),
+                   "dep_filename", dep_filename,
+                   "proto_filename", proto_filename);
   }
   printer->Print("\n\n");
 }


### PR DESCRIPTION
Replaces https://github.com/grpc/grpc-web/pull/1311, which I created with my non-corporate account. I can use the corporate account to meet the CLA requirement.

I was experiencing a long import path in the generated code that doesn't work. Outputting the proto file that corresponds to a JS import is helpful for both diagnosing the issue and writing a wrapper for altering the import path to my satisfaction.

Before:

```js
import * as github_com_gonzojive_rules_ts_proto_example_prefix_greeting_pb from '../../../../../github.com/gonzojive/rules_ts_proto/example/prefix/greeting_pb';
```

After:

```js
import * as github_com_gonzojive_rules_ts_proto_example_prefix_greeting_pb from '../../../../../github.com/gonzojive/rules_ts_proto/example/prefix/greeting_pb'; // proto import: "github.com/gonzojive/rules_ts_proto/example/prefix/greeting.proto"
```