### PR TITLE
Fix build for `interop-test` docker image

### DIFF
--- a/net/grpc/gateway/docker/interop_client/Dockerfile
+++ b/net/grpc/gateway/docker/interop_client/Dockerfile
@@ -29,6 +29,8 @@ RUN npm install && \
   cp index.html /var/www/html && \
   cp dist/main.js /var/www/html/dist
 
+RUN apt-get -qq update && apt-get -qq install -y python
+
 WORKDIR /var/www/html
 
 EXPOSE 8081

--- a/test/interop/package.json
+++ b/test/interop/package.json
@@ -11,6 +11,7 @@
     "grpc-web": "~1.4.2"
   },
   "devDependencies": {
+    "assert": "^2.0.0",
     "minimist": "~1.2.5",
     "mocha": "~7.1.1",
     "webpack": "~5.82.1",


### PR DESCRIPTION
The in-browser test is still not working, but it can at least build and start :)

- `assert` is required after upgrading webpack to version 5+