### PR TITLE
Install python in `prereqs` image

### DIFF
--- a/net/grpc/gateway/docker/interop_client/Dockerfile
+++ b/net/grpc/gateway/docker/interop_client/Dockerfile
@@ -29,8 +29,6 @@ RUN npm install && \
   cp index.html /var/www/html && \
   cp dist/main.js /var/www/html/dist
 
-RUN apt-get -qq update && apt-get -qq install -y python
-
 WORKDIR /var/www/html
 
 EXPOSE 8081

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -54,6 +54,8 @@ FROM node:20.0.0-bullseye AS copy-and-build
 ARG MAKEFLAGS=-j8
 ARG BAZEL_VERSION=4.1.0
 
+RUN apt-get -qq update && apt-get -qq install -y python
+
 RUN mkdir -p /var/www/html/dist
 RUN echo "\nloglevel=error\n" >> $HOME/.npmrc
 


### PR DESCRIPTION
Maybe `buildpack-deps` has recently removed python installation by default and hence is observing some errors. (Thanks @Kaszanas for noticing :))

Fixes #1349