### PR TITLE
Use cloned init_submodules.sh in prereqs (#1349)

### DIFF
--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -42,7 +42,6 @@ RUN wget -nv -O buildifier \
 WORKDIR /github/grpc-web
 
 RUN git clone https://github.com/grpc/grpc-web .
-COPY ./scripts/init_submodules.sh ./scripts/
 RUN ./scripts/init_submodules.sh
 
 


### PR DESCRIPTION
The problem with building the docker-compose example was due to the additional line copying the `init_submodule.sh` script from the context. The line just above was cloning the repository though, so there is no need to COPY that script.

This is supposed to be solving the issue: https://github.com/grpc/grpc-web/issues/1349

While solving this, another issue was discovered: 