### PR TITLE
Output comments for imports in .d.ts like '// proto: "foo/bar.proto"'

### DIFF
--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -942,9 +942,10 @@ void PrintProtoDtsFile(Printer* printer, const FileDescriptor* file) {
   for (int i = 0; i < file->dependency_count(); i++) {
     const string& name = file->dependency(i)->name();
     // We need to give each cross-file import an alias.
-    printer->Print("import * as $alias$ from '$dep_filename$_pb';\n", "alias",
-                   ModuleAlias(name), "dep_filename",
-                   GetRootPath(file->name(), name) + StripProto(name));
+    printer->Print("import * as $alias$ from '$dep_filename$_pb'; // proto import: \"$proto_filename$\"\n", 
+                   "alias", ModuleAlias(name),
+                   "dep_filename", GetRootPath(file->name(), name) + StripProto(name),
+                   "proto_filename", name);
   }
   printer->Print("\n\n");
 


### PR DESCRIPTION
Followup to https://github.com/grpc/grpc-web/pull/1313 for .d.ts files.

As with https://github.com/grpc/grpc-web/pull/1313, this helps with diagnostic and with rewriting imports generated by grpc-web.