### PR TITLE
Update http2_protocol_options pattern

### DIFF
--- a/net/grpc/gateway/examples/echo/envoy.yaml
+++ b/net/grpc/gateway/examples/echo/envoy.yaml
@@ -48,7 +48,12 @@ static_resources:
     - name: echo_service
       connect_timeout: 0.25s
       type: logical_dns
-      http2_protocol_options: {}
+      # HTTP/2 support
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
       lb_policy: round_robin
       load_assignment:
         cluster_name: cluster_0

--- a/net/grpc/gateway/examples/echo/tutorial.md
+++ b/net/grpc/gateway/examples/echo/tutorial.md
@@ -83,7 +83,12 @@ static_resources:
     - name: echo_service
       connect_timeout: 0.25s
       type: logical_dns
-      http2_protocol_options: {}
+      # HTTP/2 support
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
       lb_policy: round_robin
       load_assignment:
         cluster_name: cluster_0

--- a/net/grpc/gateway/examples/helloworld/README.md
+++ b/net/grpc/gateway/examples/helloworld/README.md
@@ -137,7 +137,12 @@ static_resources:
     - name: greeter_service
       connect_timeout: 0.25s
       type: logical_dns
-      http2_protocol_options: {}
+      # HTTP/2 support
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
       lb_policy: round_robin
       load_assignment:
         cluster_name: cluster_0

--- a/net/grpc/gateway/examples/helloworld/envoy.yaml
+++ b/net/grpc/gateway/examples/helloworld/envoy.yaml
@@ -48,7 +48,12 @@ static_resources:
     - name: greeter_service
       connect_timeout: 0.25s
       type: logical_dns
-      http2_protocol_options: {}
+      # HTTP/2 support
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
       lb_policy: round_robin
       # win/mac hosts: Use address: host.docker.internal instead of address: localhost in the line below
       load_assignment:

--- a/test/interop/envoy.yaml
+++ b/test/interop/envoy.yaml
@@ -48,7 +48,12 @@ static_resources:
     - name: interop_service
       connect_timeout: 0.25s
       type: logical_dns
-      http2_protocol_options: {}
+      # HTTP/2 support
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
       lb_policy: round_robin
       load_assignment:
         cluster_name: cluster_0


### PR DESCRIPTION
In my Envoy logs I see a number of entries like this:

> `[2024-01-22 15:44:47.698][620][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.cluster.v3.Cluster Using deprecated option 'envoy.config.cluster.v3.Cluster.http2_protocol_options' from file cluster.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.`

I believe this stems from https://github.com/envoyproxy/envoy/pull/14079 (@alyssawilk) but the examples and tests in this repo haven't been updated. I lifted [this diff](https://github.com/envoyproxy/envoy/pull/14079/files#diff-fa199c63de1a5dba807902ac586a6108a08913f78c6ce0040211f8015c66201e) from that PR and applied to all mentions of this string in this repo. I verified this change works in my Envoy application.