### PR TITLE
[vote]Added Active maintainers into MAINTAINERS.md.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,8 +8,9 @@ See [CONTRIBUTING.md](https://github.com/grpc/grpc-community/blob/master/CONTRIB
 for general contribution guidelines.
 
 ## Maintainers (in alphabetical order)
-- [stanley-cheung](https://github.com/stanley-cheung), Google Inc.
+- [sampajano](https://github.com/sampajano), Google Inc.
 - [wenbozhu](https://github.com/wenbozhu), Google Inc.
 
 ## Emeritus Maintainers (in alphabetical order)
-- [fengli79](https://github.com/fengli79), Google Inc.
+- [fengli79](https://github.com/fengli79)
+- [stanley-cheung](https://github.com/stanley-cheung)


### PR DESCRIPTION
[vote] Added sampajano into grpc/grpc-web active maintainers list. Removed  @stanley-cheung from active maintainers list and moved them to emeritus. Removed org from emeritus. Please comment as "Agree" if you agree to the change, if not please comment as "Disagree". Your comment will be counted as a vote. The PR needs to stay open for 14 days, I.e. till 15th June 2024 as per governance guidelines