### PR TITLE
Upgrade to Bazel 6.5.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,19 +13,19 @@ http_archive(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "ba0650be1b169d24908eeddbe6107f011d8df0da5b1a5a4449a913b10e578faf",
-    strip_prefix = "protobuf-3.19.4",
+    sha256 = "7beed9c511d632cff7c22ac0094dd7720e550153039d5da7e059bcceb488474a",
+    strip_prefix = "protobuf-25.0",
     urls = [
-        "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protobuf-all-3.19.4.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protobuf-25.0.tar.gz",
     ],
 )
 
 http_archive(
     name = "com_github_grpc_grpc",
-    sha256 = "de2d3168e77e5ffb27758b07e87f6066fd0d8087fe272f278771e7780e6aaacb",
-    strip_prefix = "grpc-1.44.0",
+    sha256 = "8579095a31e280d0c5fcc81ea0a2a0efb2900dbfbac0eb018a961a5be22e076e",
+    strip_prefix = "grpc-1.64.2",
     urls = [
-        "https://github.com/grpc/grpc/archive/v1.44.0.zip",
+        "https://github.com/grpc/grpc/archive/v1.64.2.zip",
     ],
 )
 

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -52,7 +52,7 @@ RUN ./scripts/init_submodules.sh
 FROM node:20.0.0-bullseye AS copy-and-build
 
 ARG MAKEFLAGS=-j8
-ARG BAZEL_VERSION=4.1.0
+ARG BAZEL_VERSION=6.5.0
 
 RUN apt-get -qq update && apt-get -qq install -y python
 


### PR DESCRIPTION
Updated Bazel to `6.5.0`
- `4.1.0` no longer works on my mac.
- `7.2.0` seems not yet supported by internal CI tooling :)

Also upgraded
- Protobuf -> `25.0` (`27.0` is generating errors :))
- gRPC Bazel -> `1.64.2`