### PR TITLE
[Experiment] Generate `thenableCall()` instead of `unaryCall()`

### DIFF
--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -689,7 +689,7 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Outdent();
           printer->Print(vars,
                          "}\n"
-                         "return this.client_.unaryCall(\n");
+                         "return this.client_.thenableCall(\n");
           printer->Print(vars,
                          "this.hostname_ +\n"
                          "  '/$package_dot$$service_name$/$method_name$',\n"
@@ -1179,7 +1179,7 @@ void PrintPromiseUnaryCall(Printer* printer, std::map<string, string> vars) {
   printer->Indent();
   printer->Print(vars,
                  "  function(request, metadata) {\n"
-                 "return this.client_.unaryCall(this.hostname_ +\n");
+                 "return this.client_.thenableCall(this.hostname_ +\n");
   printer->Indent();
   printer->Indent();
   if (vars["mode"] == GetModeVar(Mode::OP)) {

--- a/packages/grpc-web/externs.js
+++ b/packages/grpc-web/externs.js
@@ -10,11 +10,6 @@ module.ClientReadableStream.prototype.removeListener =
   function(eventType, callback) {};
 module.ClientReadableStream.prototype.cancel = function() {};
 
-module.GenericClient = function() {};
-module.GenericClient.prototype.unaryCall = function(request) {};
-module.GenericClient.prototype.call = function(requestMessage,
-                                               methodDescriptor) {};
-
 module.UnaryInterceptor = function() {};
 module.UnaryInterceptor.prototype.intercept = function(request, invoker) {};
 


### PR DESCRIPTION
This came up in https://github.com/grpc/grpc-web/issues/1331

---

`thenableCall()` is what's currently exposed on the `AbstractClientBase` API.
https://github.com/grpc/grpc-web/blob/master/packages/grpc-web/index.d.ts

Which was added in the following commit for the sake of supporting "Generic API" (which no longer applies)
https://github.com/grpc/grpc-web/commit/916d6cbef42e10c301c7fd964869f3afdbcb7b17

---

`unaryCall()` is just an alias for `thenableCall()`, where it simply [calls](https://github.com/grpc/grpc-web/blob/8ab32b945ca0530222593127e9431a455eff24a8/javascript/net/grpc/web/grpcwebclientbase.js#L158-L161) the latter.

The right long-term fix is probably to get rid of `thenableCall()` in favor of `unaryCall()`, as the latter sounds like a better API (more clear).