### PR TITLE
Fix webpack command in tutorials

### DIFF
--- a/net/grpc/gateway/examples/echo/tutorial.md
+++ b/net/grpc/gateway/examples/echo/tutorial.md
@@ -191,7 +191,7 @@ into one single JS library that can be used in the browser.
 
 ```sh
 $ npm install
-$ npx webpack client.js
+$ npx webpack ./client.js
 ```
 
 Now embed `dist/main.js` into your project and see it in action!

--- a/net/grpc/gateway/examples/helloworld/README.md
+++ b/net/grpc/gateway/examples/helloworld/README.md
@@ -284,7 +284,7 @@ can be consumed by the browser.
 
 ```sh
 $ npm install
-$ npx webpack client.js
+$ npx webpack ./client.js
 ```
 
 Here we use `webpack` and give it an entry point `client.js`. You can also use


### PR DESCRIPTION
Without `./`, you get this error:

```
Module not found: Error: Can't resolve 'client.js' in '/[...]/grpc-web/net/grpc/gateway/examples/helloworld'
Did you mean './client.js'?
Requests that should resolve in the current directory need to start with './'.
```