### PR TITLE
Enhance HTTP Status Handling in Unary Calls for gRPC-Web

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -153,8 +153,9 @@ class GrpcWebClientReadableStream {
         byteSource = new Uint8Array(
             /** @type {!ArrayBuffer} */ (self.xhr_.getResponse()));
       } else {
+        const metadata = {'httpStatusCode': self.xhr_.getStatus().toString()};
         self.handleError_(
-            new RpcError(StatusCode.UNKNOWN, 'Unknown Content-type received.'));
+            new RpcError(StatusCode.UNKNOWN, 'Unknown Content-type received.', metadata));
         return;
       }
       let messages = null;
@@ -257,11 +258,14 @@ class GrpcWebClientReadableStream {
           return;
         }
         let errorMessage = ErrorCode.getDebugMessage(lastErrorCode);
+
+        const metadata = {};
         if (xhrStatusCode != -1) {
           errorMessage += ', http status code: ' + xhrStatusCode;
+          metadata['httpStatusCode'] = self.xhr_.getStatus().toString();
         }
 
-        self.handleError_(new RpcError(grpcStatusCode, errorMessage));
+        self.handleError_(new RpcError(grpcStatusCode, errorMessage, metadata));
         return;
       }
 


### PR DESCRIPTION
# Pull Request: Enhance HTTP Status Handling in Unary Calls for gRPC-Web

## Background
When using gRPC-Web with a reverse proxy like NGINX, there are scenarios where the proxy may return HTTP status codes (e.g., `503`, `505`) without invoking the actual gRPC service. In such cases, the gRPC-Web library throws an `RpcError` with a `StatusCode.UNKNOWN`. This limits the ability to differentiate between HTTP errors and makes it challenging to implement robust client-side error handling based on specific HTTP statuses.

## Changes introduced in this PR
1. **Addition of `httpStatusCode` to Errors**
   - Modified the error creation logic in [`grpcwebclientreadablestream.js`](https://github.com/grpc/grpc-web/blob/master/javascript/net/grpc/web/grpcwebclientreadablestream.js#L156) to include the `httpStatusCode` from the XHR object.
   - This ensures that the exact HTTP status code is accessible in unary call errors.
   - HTTP Status is added as string to fit Metadata type

2. **Enhanced `complete` event for streaming**
   - Updated the behavior of the `complete` event for streaming calls to mirror the unary call changes.
   - The `httpStatusCode` is now included in metadata when firing `status` event.

## Alternatives
As an alternative resolution i can prepare solution similar to [this line](https://github.com/grpc/grpc-web/blob/master/javascript/net/grpc/web/grpcwebclientreadablestream.js#L261), so the final result for UNKNOWN error could be handled like:
```diff
-    new RpcError(StatusCode.UNKNOWN, 'Unknown Content-type received.'));
+    new RpcError(StatusCode.UNKNOWN, 'Unknown Content-type received, http status code: ' + self.xhr_.getStatus()));
```

## Example behaviour before and after this change
### Before:
Unary call errors always return `RpcError` with `StatusCode.UNKNOWN`, irrespective of the HTTP status code.

### After:
Errors now include the `httpStatusCode` field in metadata, enabling better decision-making on the client side.

Example:
```javascript
{
  code: StatusCode.UNKNOWN,
  message: "An error occurred",
  metadata: {
    httpStatusCode: '503'
  }
}
```

## Open Questions
1. **Acceptability**: Is adding the `httpStatusCode` to the `RpcError` object an acceptable enhancement for unary and streaming calls?
2. **Metadata Handling**: Should we consider modifying metadata to accept numbers for better handling of HTTP-specific errors?  
3. **Alternative**: Is proposed solution ok, or you want to try with proposed alternative?

## Why This Change Is Valuable
- **Improved Client-Side Error Handling**: Enables applications to differentiate between HTTP-specific errors (e.g., `503`, `505`) and gRPC errors, particularly when intermediary layers like NGINX are used.
- **Consistency**: Aligns the behaviour of unary calls with streaming calls, ensuring both provide detailed error context.
- **Enhanced Debugging**: Provides developers with the HTTP status code directly, reducing time spent diagnosing issues caused by reverse proxies.
