### PR TITLE
Add API support for aborting promise calls

### DIFF
--- a/javascript/net/grpc/web/abstractclientbase.js
+++ b/javascript/net/grpc/web/abstractclientbase.js
@@ -33,6 +33,20 @@ const RpcError = goog.require('grpc.web.RpcError');
 
 
 /**
+ * @constructor
+ * @struct
+ * @final
+ */
+const PromiseCallOptions = function() {};
+
+/**
+ * An AbortSignal to abort the call.
+ * @type {AbortSignal|undefined}
+ */
+PromiseCallOptions.prototype.signal;
+
+
+/**
  * This interface represents a grpc-web client
  * @interface
  */
@@ -62,10 +76,11 @@ const AbstractClientBase = class {
    * @param {!Object<string, string>} metadata User defined call metadata
    * @param {!MethodDescriptor<REQUEST, RESPONSE>}
    *   methodDescriptor Information of this RPC method
+   * @param options Options for the call
    * @return {!IThenable<RESPONSE>}
    *   A promise that resolves to the response message
    */
-  thenableCall(method, requestMessage, metadata, methodDescriptor) {}
+  thenableCall(method, requestMessage, metadata, methodDescriptor, options) {}
 
   /**
    * @abstract
@@ -78,21 +93,19 @@ const AbstractClientBase = class {
    * @return {!ClientReadableStream<RESPONSE>} The Client Readable Stream
    */
   serverStreaming(method, requestMessage, metadata, methodDescriptor) {}
-
-  /**
-   * Get the hostname of the current request.
-   * @static
-   * @template REQUEST, RESPONSE
-   * @param {string} method
-   * @param {!MethodDescriptor<REQUEST,RESPONSE>} methodDescriptor
-   * @return {string}
-   */
-  static getHostname(method, methodDescriptor) {
-    // method = hostname + methodDescriptor.name(relative path of this method)
-    return method.substr(0, method.length - methodDescriptor.name.length);
-  }
 };
 
+/**
+ * Get the hostname of the current request.
+ * @template REQUEST, RESPONSE
+ * @param {string} method
+ * @param {!MethodDescriptor<REQUEST,RESPONSE>} methodDescriptor
+ * @return {string}
+ */
+function getHostname(method, methodDescriptor) {
+  // method = hostname + methodDescriptor.name(relative path of this method)
+  return method.substr(0, method.length - methodDescriptor.name.length);
+}
 
 
-exports = AbstractClientBase;
+exports = {AbstractClientBase, PromiseCallOptions, getHostname};

--- a/packages/grpc-web/docker/jsunit-test/Dockerfile
+++ b/packages/grpc-web/docker/jsunit-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-chrome:93.0.4577.63
+FROM selenium/standalone-chrome:112.0.5615.165
 
 # Matching the node version used in the node:20.0.0-bullseye image.
 ARG NODE_VERSION=20.0.0

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -7,7 +7,8 @@ declare module "grpc-web" {
       method: string,
       request: REQ,
       metadata: Metadata,
-      methodDescriptor: MethodDescriptor<REQ, RESP>
+      methodDescriptor: MethodDescriptor<REQ, RESP>,
+      options?: PromiseCallOptions
     ): Promise<RESP>;
 
     rpcCall<REQ, RESP> (
@@ -64,8 +65,10 @@ declare module "grpc-web" {
       Promise<UnaryResponse<REQ, RESP>>): Promise<UnaryResponse<REQ, RESP>>;
   }
 
-  export class CallOptions {
-    constructor(options: { [index: string]: any; });
+  /** Options for gRPC-Web calls returning a Promise. */
+  export interface PromiseCallOptions {
+    /** An AbortSignal to abort the call. */
+    readonly signal?: AbortSignal;
   }
 
   export class MethodDescriptor<REQ, RESP> {
@@ -82,7 +85,6 @@ declare module "grpc-web" {
     getRequestMessage(): REQ;
     getMethodDescriptor(): MethodDescriptor<REQ, RESP>;
     getMetadata(): Metadata;
-    getCallOptions(): CallOptions;
   }
 
   export class UnaryResponse<REQ, RESP> {

--- a/packages/grpc-web/scripts/run_jsunit_tests.sh
+++ b/packages/grpc-web/scripts/run_jsunit_tests.sh
@@ -44,8 +44,8 @@ trap cleanup EXIT
 
 echo "Using Headless Chrome."
 # Updates Selenium Webdriver.
-echo "$PROTRACTOR_BIN_PATH/webdriver-manager update --versions.chrome=93.0.4577.63 --gecko=false"
-$PROTRACTOR_BIN_PATH/webdriver-manager update --versions.chrome=93.0.4577.63 --gecko=false
+echo "$PROTRACTOR_BIN_PATH/webdriver-manager update --versions.chrome=112.0.5615.165 --gecko=false"
+$PROTRACTOR_BIN_PATH/webdriver-manager update --versions.chrome=112.0.5615.165 --gecko=false
 
 # Run the tests using Protractor! (Protractor should run selenium automatically)
 $PROTRACTOR_BIN_PATH/protractor protractor.conf.js


### PR DESCRIPTION
For #1096

- Also removed `CallOptions` in favor of `PromiseCallOptions` (to align with internal codebase)
- Also updated chrome to `112.0.5615.165` for supporting abort with reason.

TODO:

- Include this option in generated code stub