### PR TITLE
Fix protoc plugin docker image build

### DIFF
--- a/net/grpc/gateway/docker/protoc_plugin/Dockerfile
+++ b/net/grpc/gateway/docker/protoc_plugin/Dockerfile
@@ -38,6 +38,7 @@ RUN rm -rf /usr/local/include/absl /usr/local/lib/libabsl*
 WORKDIR /github/grpc-web/third_party/abseil-cpp
 RUN cmake -S . -B cmake/build \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DCMAKE_CXX_STANDARD=17 \
     -DCMAKE_BUILD_TYPE=Release && \
     cmake --build cmake/build --target install
 


### PR DESCRIPTION
Fixes #1485 

Got an error message when building the `protoc_plugin` docker image

```
cmake -S . -B cmake/build     -DCMAKE_POSITION_INDEPENDENT_CODE=ON     -DCMAKE_BUILD_TYPE=Release 
CMake Error at CMake/AbseilDll.cmake:722 (message):
  The compiler defaults to or is configured for C++ < 17.  C++ >= 17 is
  required and Abseil and all libraries that use Abseil must use the same C++
  language standard
```