### PR TITLE
Updates Closure compiler (`20250820.0.0`) and library

### DIFF
--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -27,9 +27,9 @@
   "devDependencies": {
     "@types/google-protobuf": "~3.15.12",
     "command-exists": "~1.2.8",
-    "google-closure-compiler": "~20200224.0.0",
+    "google-closure-compiler": "^20250820.0.0",
     "google-closure-deps": "~20210601.0.0",
-    "google-closure-library": "~20210808.0.0",
+    "google-closure-library": "^20230802.0.0",
     "google-protobuf": "~3.21.4",
     "gulp": "~4.0.2",
     "gulp-connect": "~5.7.0",


### PR DESCRIPTION
Updates:

- "google-closure-compiler": "^20250820.0.0",
- "google-closure-library": "^20230802.0.0",