### PR TITLE
feat(generator): add force_int64_string option to prevent int64 preci…

### DIFF
--- a/packages/grpc-web/test/protos/int64_precision_test.proto
+++ b/packages/grpc-web/test/protos/int64_precision_test.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/descriptor.proto";
+
+message Int64PrecisionTest {
+  int64 normal_int64 = 1;
+  int64 string_int64 = 2 [jstype = JS_STRING];
+  uint64 normal_uint64 = 3;
+  uint64 string_uint64 = 4 [jstype = JS_STRING];
+  sint64 normal_sint64 = 5;
+  sint64 string_sint64 = 6 [jstype = JS_STRING];
+  fixed64 normal_fixed64 = 7;
+  fixed64 string_fixed64 = 8 [jstype = JS_STRING];
+  sfixed64 normal_sfixed64 = 9;
+  sfixed64 string_sfixed64 = 10 [jstype = JS_STRING];
+}


### PR DESCRIPTION
## feat(generator): add force_int64_string option to prevent int64 precision loss

**Fixes #1229**

### Problem

Large 64-bit integers lose precision when mapped to JavaScript's `number` type in gRPC-Web generated TypeScript definitions. This is a well-known issue affecting JavaScript/TypeScript applications that work with large integers.

**Example:**
```proto
message User {
  int64 user_id = 1;
}
```

**Generated TypeScript (current behavior):**
```typescript
getUserId(): number;  // ❌ Precision loss for values > 2^53
setUserId(value: number): void;
```

**Problem demonstration:**
```javascript
const userId = 9024037547368883040;  // Large int64 value
console.log(userId);  // Output: 9024037547368883200 (precision lost!)
```

### Solution

This PR adds a new CLI option `force_int64_string=True` that forces all `int64`/`uint64` fields to be generated as `string` type, preserving full precision.

**Usage:**
```bash
protoc --grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext,force_int64_string=True:. your_proto.proto
```

**Generated TypeScript (with fix):**
```typescript
getUserId(): string;  // ✅ Full precision preserved
setUserId(value: string): void;
```

### Implementation Details

- **New CLI option**: `force_int64_string=True` 
- **Backward compatible**: Existing `[jstype = JS_STRING]` field-level option still works
- **Comprehensive coverage**: Affects all 64-bit integer types (`int64`, `uint64`, `sint64`, `fixed64`, `sfixed64`)
- **Type-safe**: Maintains TypeScript type safety with string-based integers

### Changes Made

1. **Enhanced `JSElementType` function** to check both `jstype` option and CLI flag
2. **Updated function signatures** throughout the call chain to pass the `force_int64_string` parameter
3. **Added `GeneratorOptions` support** for parsing the new CLI option
4. **Added test proto file** to verify functionality

### Testing

✅ **Default behavior**: Normal fields → `number`, `[jstype = JS_STRING]` → `string`  
✅ **force_int64_string=True**: All int64 fields → `string`  
✅ **Backward compatibility**: Existing behavior preserved  

### Migration Guide

**For new projects:**
```bash
# Use the new option to prevent precision loss
protoc --grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext,force_int64_string=True:. your_proto.proto
```

**For existing projects:**
- Continue using `[jstype = JS_STRING]` for specific fields
- Or migrate to `force_int64_string=True` for global control
