### PR TITLE
fix-944 - Added unary Call in abstractclientbase.

### DIFF
--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -710,7 +710,7 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Outdent();
           printer->Print(vars,
                          "}\n"
-                         "return this.client_.thenableCall(\n");
+                         "return this.client_.unaryCall(\n");
           printer->Print(vars,
                          "this.hostname_ +\n"
                          "  '/$package_dot$$service_name$/$method_name$',\n"
@@ -842,8 +842,8 @@ void PrintProtoDtsMessage(Printer* printer, const Descriptor* desc,
   printer->Print(vars, "export class $class_name$ extends jspb.Message {\n");
   printer->Indent();
 
-  printer->Print(vars, "constructor(opt_data?: $class_name$.AsObject);\n");
-  
+  printer->Print(vars, "constructor();\n" "constructor(opt_data?: $class_name$.AsObject);\n");
+
   for (int i = 0; i < desc->field_count(); i++) {
     const FieldDescriptor* field = desc->field(i);
 

--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -710,7 +710,7 @@ void PrintTypescriptFile(Printer* printer, const FileDescriptor* file,
           printer->Outdent();
           printer->Print(vars,
                          "}\n"
-                         "return this.client_.unaryCall(\n");
+                         "return this.client_.thenableCall(\n");
           printer->Print(vars,
                          "this.hostname_ +\n"
                          "  '/$package_dot$$service_name$/$method_name$',\n"

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -10,6 +10,13 @@ declare module "grpc-web" {
       methodDescriptor: MethodDescriptor<REQ, RESP>,
       options?: PromiseCallOptions
     ): Promise<RESP>;
+  
+    unaryCall<REQ, RESP>(
+      method: string,
+      request: REQ,
+      metadata: Metadata,
+      methodDescriptor: MethodDescriptor<REQ, RESP> 
+    ): Promise<RESP>;
 
     rpcCall<REQ, RESP> (
       method: string,


### PR DESCRIPTION
fix-[944](https://github.com/grpc/grpc-web/issues/944) Updates the generated gRPC-Web client to add a typed unaryCall implementation in AbstractClientBase, improving support for Promise-style unary calls. This makes the client more ergonomic for TypeScript usage without changing any existing runtime behavior. It also adjusts the generated constructor types to improve compatibility with generic instantiation patterns.