### PR TITLE
Support unary interceptors in callback-style clients (rpcCall)

### DIFF
--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -36,6 +36,7 @@ const HttpCors = goog.require('goog.net.rpc.HttpCors');
 const MethodDescriptor = goog.requireType('grpc.web.MethodDescriptor');
 const Request = goog.require('grpc.web.Request');
 const RpcError = goog.require('grpc.web.RpcError');
+const MethodType = goog.require('grpc.web.MethodType');
 const StatusCode = goog.require('grpc.web.StatusCode');
 const XhrIo = goog.require('goog.net.XhrIo');
 const googCrypt = goog.require('goog.crypt.base64');
@@ -103,7 +104,7 @@ class GrpcWebClientBase {
   rpcCall(method, requestMessage, metadata, methodDescriptor, callback) {
     const hostname = getHostname(method, methodDescriptor);
 
-    if (methodDescriptor.getMethodType() === 'unary' && this.unaryInterceptors_.length > 0) {
+    if (methodDescriptor.getMethodType() === MethodType.UNARY && this.unaryInterceptors_.length > 0) {
       let realStream;
       let cancelled = false;
       const listeners = [];
@@ -137,47 +138,37 @@ class GrpcWebClientBase {
         }
       };
 
-      const initialInvoker = (request) => new Promise((resolve, reject) => {
-        realStream = this.startStream_(request, hostname);
-        if (cancelled) {
-          realStream.cancel();
-        }
-        listeners.forEach(l => realStream.on(l.type, l.cb));
+      const streamInvoker = GrpcWebClientBase.runInterceptors_(
+          (req) => this.startStream_(req, hostname),
+          this.streamInterceptors_);
 
-        let unaryMetadata;
-        let unaryStatus;
-        let unaryMsg;
-        GrpcWebClientBase.setCallback_(
-            realStream,
-            (error, response, status, metadata, unaryResponseReceived) => {
-              if (error) {
-                reject(error);
-              } else if (unaryResponseReceived) {
-                unaryMsg = response;
-              } else if (status) {
-                unaryStatus = status;
-              } else if (metadata) {
-                unaryMetadata = metadata;
-              } else {
-                resolve(request.getMethodDescriptor().createUnaryResponse(
-                    unaryMsg, unaryMetadata, unaryStatus));
-              }
-            },
-            true);
-      });
+      const initialInvoker = GrpcWebClientBase.makeUnaryInvoker_(
+          streamInvoker, null, (stream) => {
+            realStream = stream;
+            if (cancelled) {
+              realStream.cancel();
+            }
+            listeners.forEach(l => realStream.on(l.type, l.cb));
+          });
 
       const invoker = GrpcWebClientBase.runInterceptors_(
           initialInvoker, this.unaryInterceptors_);
 
-      const unaryResponse = /** @type {!Promise<?>} */ (invoker.call(
-          this, methodDescriptor.createRequest(requestMessage, metadata)));
-
-      unaryResponse.then(
+      Promise.resolve().then(() => invoker.call(
+          this, methodDescriptor.createRequest(requestMessage, metadata)))
+      .then(
           (response) => {
             callback(null, response.getResponseMessage());
           },
           (error) => {
-            callback(/** @type {!RpcError} */ (error), null);
+            let rpcError;
+            if (error instanceof RpcError) {
+              rpcError = error;
+            } else {
+              rpcError = new RpcError(error.code || StatusCode.UNKNOWN, error.message || '');
+              if (error.metadata) rpcError.metadata = error.metadata;
+            }
+            callback(rpcError, null);
           });
 
       return new ClientUnaryCallImpl(/** @type {!ClientReadableStream<?>} */ (proxyStream));
@@ -205,49 +196,11 @@ class GrpcWebClientBase {
       method, requestMessage, metadata, methodDescriptor, options = {}) {
     const hostname = getHostname(method, methodDescriptor);
     const signal = options && options.signal;
-    const initialInvoker = (request) => new Promise((resolve, reject) => {
-      // If the signal is already aborted, immediately reject the promise
-      // and don't issue the call.
-      if (signal && signal.aborted) {
-        const error = new RpcError(StatusCode.CANCELLED, 'Aborted');
-        error.cause = signal.reason;
-        reject(error);
-        return;
-      }
+    
+    const initialInvoker = GrpcWebClientBase.makeUnaryInvoker_(
+        (req) => this.startStream_(req, hostname),
+        signal, null);
 
-      const stream = this.startStream_(request, hostname);
-      let unaryMetadata;
-      let unaryStatus;
-      let unaryMsg;
-      GrpcWebClientBase.setCallback_(
-          stream,
-          (error, response, status, metadata, unaryResponseReceived) => {
-            if (error) {
-              reject(error);
-            } else if (unaryResponseReceived) {
-              unaryMsg = response;
-            } else if (status) {
-              unaryStatus = status;
-            } else if (metadata) {
-              unaryMetadata = metadata;
-            } else {
-              resolve(request.getMethodDescriptor().createUnaryResponse(
-                  unaryMsg, unaryMetadata, unaryStatus));
-            }
-          },
-          true);
-
-      // Wire up cancellation from the abort signal, if any.
-      if (signal) {
-        signal.addEventListener('abort', () => {
-          stream.cancel();
-
-          const error = new RpcError(StatusCode.CANCELLED, 'Aborted');
-          error.cause = /** @type {!AbortSignal} */ (signal).reason;
-          reject(error);
-        });
-      }
-    });
     const invoker = GrpcWebClientBase.runInterceptors_(
         initialInvoker, this.unaryInterceptors_);
     const unaryResponse = /** @type {!Promise<?>} */ (invoker.call(
@@ -467,6 +420,63 @@ class GrpcWebClientBase {
   static setCorsOverride_(method, headerObject) {
     return /** @type {string} */ (HttpCors.setHttpHeadersWithOverwriteParam(
         method, HttpCors.HTTP_HEADERS_PARAM_NAME, headerObject));
+  }
+
+  /**
+   * @private
+   * @static
+   * @template REQUEST, RESPONSE
+   * @param {function(!Request<REQUEST,RESPONSE>):!ClientReadableStream<RESPONSE>} streamCreator
+   * @param {?AbortSignal} signal
+   * @param {?function(!ClientReadableStream<RESPONSE>)} onStreamCreated
+   * @return {function(!Request<REQUEST,RESPONSE>):!Promise<?>}
+   */
+  static makeUnaryInvoker_(streamCreator, signal, onStreamCreated) {
+    return (request) => new Promise((resolve, reject) => {
+      if (signal && signal.aborted) {
+        const error = new RpcError(StatusCode.CANCELLED, 'Aborted');
+        error.cause = signal.reason;
+        reject(error);
+        return;
+      }
+
+      const stream = streamCreator(request);
+      
+      let unaryMetadata;
+      let unaryStatus;
+      let unaryMsg;
+      
+      GrpcWebClientBase.setCallback_(
+          stream,
+          (error, response, status, metadata, unaryResponseReceived) => {
+            if (error) {
+              reject(error);
+            } else if (unaryResponseReceived) {
+              unaryMsg = response;
+            } else if (status) {
+              unaryStatus = status;
+            } else if (metadata) {
+              unaryMetadata = metadata;
+            } else {
+              resolve(request.getMethodDescriptor().createUnaryResponse(
+                  unaryMsg, unaryMetadata, unaryStatus));
+            }
+          },
+          true);
+
+      if (onStreamCreated) {
+        onStreamCreated(stream);
+      }
+
+      if (signal) {
+        signal.addEventListener('abort', () => {
+          stream.cancel();
+          const error = new RpcError(StatusCode.CANCELLED, 'Aborted');
+          error.cause = /** @type {!AbortSignal} */ (signal).reason;
+          reject(error);
+        });
+      }
+    });
   }
 
   /**

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -102,6 +102,87 @@ class GrpcWebClientBase {
    */
   rpcCall(method, requestMessage, metadata, methodDescriptor, callback) {
     const hostname = getHostname(method, methodDescriptor);
+
+    if (methodDescriptor.getMethodType() === 'unary' && this.unaryInterceptors_.length > 0) {
+      let realStream;
+      let cancelled = false;
+      const listeners = [];
+
+      // Unary interceptors return a Promise, but rpcCall must return a stream
+      // immediately. This proxy stream queues up listeners and handles cancellation
+      // until the real stream is created asynchronously by the interceptor chain.
+      const proxyStream = {
+        on: function(type, cb) {
+          if (realStream) {
+            realStream.on(type, cb);
+          } else {
+            listeners.push({type, cb});
+          }
+          return this;
+        },
+        removeListener: function(type, cb) {
+          if (realStream) {
+            realStream.removeListener(type, cb);
+          } else {
+            const index = listeners.findIndex(l => l.type === type && l.cb === cb);
+            if (index !== -1) {
+              listeners.splice(index, 1);
+            }
+          }
+          return this;
+        },
+        cancel: function() {
+          cancelled = true;
+          if (realStream) realStream.cancel();
+        }
+      };
+
+      const initialInvoker = (request) => new Promise((resolve, reject) => {
+        realStream = this.startStream_(request, hostname);
+        if (cancelled) {
+          realStream.cancel();
+        }
+        listeners.forEach(l => realStream.on(l.type, l.cb));
+
+        let unaryMetadata;
+        let unaryStatus;
+        let unaryMsg;
+        GrpcWebClientBase.setCallback_(
+            realStream,
+            (error, response, status, metadata, unaryResponseReceived) => {
+              if (error) {
+                reject(error);
+              } else if (unaryResponseReceived) {
+                unaryMsg = response;
+              } else if (status) {
+                unaryStatus = status;
+              } else if (metadata) {
+                unaryMetadata = metadata;
+              } else {
+                resolve(request.getMethodDescriptor().createUnaryResponse(
+                    unaryMsg, unaryMetadata, unaryStatus));
+              }
+            },
+            true);
+      });
+
+      const invoker = GrpcWebClientBase.runInterceptors_(
+          initialInvoker, this.unaryInterceptors_);
+
+      const unaryResponse = /** @type {!Promise<?>} */ (invoker.call(
+          this, methodDescriptor.createRequest(requestMessage, metadata)));
+
+      unaryResponse.then(
+          (response) => {
+            callback(null, response.getResponseMessage());
+          },
+          (error) => {
+            callback(/** @type {!RpcError} */ (error), null);
+          });
+
+      return new ClientUnaryCallImpl(/** @type {!ClientReadableStream<?>} */ (proxyStream));
+    }
+
     const invoker = GrpcWebClientBase.runInterceptors_(
         (request) => this.startStream_(request, hostname),
         this.streamInterceptors_);

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -154,9 +154,15 @@ class GrpcWebClientBase {
       const invoker = GrpcWebClientBase.runInterceptors_(
           initialInvoker, this.unaryInterceptors_);
 
-      Promise.resolve().then(() => invoker.call(
-          this, methodDescriptor.createRequest(requestMessage, metadata)))
-      .then(
+      let unaryResponse;
+      try {
+        unaryResponse = /** @type {!Promise<?>} */ (invoker.call(
+            this, methodDescriptor.createRequest(requestMessage, metadata)));
+      } catch (e) {
+        unaryResponse = Promise.reject(e);
+      }
+
+      unaryResponse.then(
           (response) => {
             callback(null, response.getResponseMessage());
           },

--- a/javascript/net/grpc/web/grpcwebclientbase_test.js
+++ b/javascript/net/grpc/web/grpcwebclientbase_test.js
@@ -22,6 +22,7 @@ const ClientReadableStream = goog.require('grpc.web.ClientReadableStream');
 const ErrorCode = goog.require('goog.net.ErrorCode');
 const GrpcWebClientBase = goog.require('grpc.web.GrpcWebClientBase');
 const MethodDescriptor = goog.require('grpc.web.MethodDescriptor');
+const MethodType = goog.require('grpc.web.MethodType');
 const ReadyState = goog.require('goog.net.XmlHttp.ReadyState');
 const Request = goog.requireType('grpc.web.Request');
 const RpcError = goog.require('grpc.web.RpcError');
@@ -29,7 +30,7 @@ const StatusCode = goog.require('grpc.web.StatusCode');
 const XhrIo = goog.require('goog.testing.net.XhrIo');
 const googCrypt = goog.require('goog.crypt.base64');
 const testSuite = goog.require('goog.testing.testSuite');
-const {StreamInterceptor} = goog.require('grpc.web.Interceptor');
+const {StreamInterceptor, UnaryInterceptor} = goog.require('grpc.web.Interceptor');
 goog.require('goog.testing.jsunit');
 
 // This parses to [ { DATA: [4, 5, 6] }, { TRAILER: "a: b" } ]
@@ -322,6 +323,31 @@ testSuite({
     assertEquals('Intercepted value', response.data);
   },
 
+  async testUnaryInterceptor() {
+    const xhr = new XhrIo();
+    const interceptor = new UnaryResponseInterceptor();
+    const methodDescriptor = new MethodDescriptor(
+        /* name= */ '', /* methodType= */ MethodType.UNARY, MockRequest, MockReply,
+        (request) => [1, 2, 3], (bytes) => new MockReply('value'));
+        
+    const client =
+        new GrpcWebClientBase({'unaryInterceptors': [interceptor]}, xhr);
+
+    const response = await new Promise((resolve, reject) => {
+      client.rpcCall(
+          'url', new MockRequest(), /* metadata= */ {}, methodDescriptor,
+          (error, response) => {
+            assertNull(error);
+            resolve(response);
+          });
+      xhr.simulatePartialResponse(
+          googCrypt.encodeByteArray(new Uint8Array(DEFAULT_RPC_RESPONSE)),
+          DEFAULT_RESPONSE_HEADERS);
+      xhr.simulateReadyStateChange(ReadyState.COMPLETE);
+    });
+    assertEquals('Intercepted value', response.data);
+  },
+
 });
 
 /** Mocks a request proto object. */
@@ -438,5 +464,28 @@ class InterceptedStream {
   removeListener(eventType, callback) {
     this.stream.removeListener(eventType, callback);
     return this;
+  }
+}
+
+/**
+ * @implements {UnaryInterceptor}
+ * @unrestricted
+ */
+class UnaryResponseInterceptor {
+  constructor() {}
+
+  /**
+   * @override
+   * @template REQUEST, RESPONSE
+   * @param {!Request<REQUEST, RESPONSE>} request
+   * @param {function(!Request<REQUEST,RESPONSE>):!Promise<!UnaryResponse<RESPONSE>>} invoker
+   * @return {!Promise<!UnaryResponse<RESPONSE>>}
+   */
+  intercept(request, invoker) {
+    return invoker(request).then((response) => {
+      const msg = response.getResponseMessage();
+      msg.data = 'Intercepted ' + msg.data;
+      return response;
+    });
   }
 }

--- a/javascript/net/grpc/web/interceptor.js
+++ b/javascript/net/grpc/web/interceptor.js
@@ -7,7 +7,8 @@
  * FooServiceClient is ClientReadableStream for BOTH unary calls and server
  * streaming calls, so StreamInterceptor is expected to be used for intercepting
  * FooServiceClient calls. The response type of PromiseClient is Promise, so use
- * UnaryInterceptor for PromiseClients.
+ * UnaryInterceptor for PromiseClients. Note that UnaryInterceptor can also be
+ * applied to unary calls in FooServiceClient if configured.
  */
 
 goog.module('grpc.web.Interceptor');


### PR DESCRIPTION
#1519 Unary interceptor is not invoked after upgrading grpc-web from 1.5.0 to 2.0.2