### PR TITLE
  chore: revert release version strings back to 2.0.2      

### DIFF
--- a/javascript/net/grpc/web/generator/grpc_generator.cc
+++ b/javascript/net/grpc/web/generator/grpc_generator.cc
@@ -81,7 +81,7 @@ const char* kKeyword[] = {
 };
 
 // Edit the version here prior to release
-static const std::string GRPC_WEB_VERSION = "2.1.0";
+static const std::string GRPC_WEB_VERSION = "2.0.2";
 
 string GetProtocVersion(GeneratorContext* context) {
   Version compiler_version;

--- a/packages/grpc-web/package.json
+++ b/packages/grpc-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-web",
-  "version": "2.1.0",
+  "version": "2.0.2",
   "author": "Google Inc.",
   "description": "gRPC-Web Client Runtime Library",
   "homepage": "https://grpc.io/",


### PR DESCRIPTION
  Reverts the release version strings inside `package.json` files and `javascript/net/grpc/web/generator/grpc_generator.cc` back to `2.0.2`.