### PR TITLE
docs: refresh Apache APISIX gRPC-web reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,9 @@ Multiple proxies support the gRPC-web protocol.
 	$ docker-compose up -d node-server grpcwebproxy binary-client
 	```
 
-3. Apache [APISIX](https://apisix.apache.org/) has also added gRPC-web support, and more details can be found [here](https://apisix.apache.org/blog/2022/01/25/apisix-grpc-web-integration/).
+3. Apache [APISIX][] supports gRPC-web proxying through its built-in
+   [`grpc-web` plugin][APISIX gRPC-web], which translates gRPC-web requests
+   into native gRPC calls for upstream services.
 
 4. [Nginx](https://www.nginx.com/) has a gRPC-web module ([doc](https://nginx.org/en/docs/http/ngx_http_grpc_module.html), [announcement](https://www.nginx.com/blog/nginx-1-13-10-grpc/))), and seems to work with simple configs, according to user [feedback](https://github.com/grpc/grpc-web/discussions/1322).
 
@@ -405,3 +407,5 @@ Multiple proxies support the gRPC-web protocol.
 [grpc-web-docs]: https://grpc.io/docs/languages/web
 [gRPC-web Go Proxy]: https://github.com/improbable-eng/grpc-web/tree/master/go/grpcwebproxy
 [Hello World example]: net/grpc/gateway/examples/helloworld
+[APISIX]: https://apisix.apache.org/
+[APISIX gRPC-web]: https://apisix.apache.org/docs/apisix/plugins/grpc-web/


### PR DESCRIPTION
### Summary

- update the existing Apache APISIX entry in the proxy interoperability list
- replace the historical blog link with the maintained `grpc-web` plugin documentation
- describe the integration in neutral, protocol-level terms

### Why

The README already lists Apache APISIX as a gRPC-web proxy. Its current link points to a 2022 integration article, while the maintained plugin reference now documents the current request handling, supported content types, CORS behavior, and configuration example.

This PR keeps the existing ecosystem entry current without changing gRPC-web behavior or adding a new example.

### Validation

- confirmed the target plugin documentation resolves to the current Apache APISIX 3.17.0 documentation
- confirmed the `grpc-web` plugin exists in the Apache APISIX 3.17.0 source
- confirmed no open Issue or PR already proposes this link update
- ran `git diff --check`
- checked that the modified lines introduce no new Markdown lint findings
- attempted the repository's `./scripts/kokoro.sh` check; the local ARM64 run stopped because the upstream test image installs an x86_64 Bazel binary, so the remaining full-build result should come from Linux x86_64 CI

### Generative tooling disclosure

This documentation update was prepared with assistance from OpenAI Codex. I reviewed the final wording and supporting sources.