### PR TITLE
limit maxReceiveMessageSize to 4MB to have parity with other runtimes

### DIFF
--- a/javascript/net/grpc/web/clientoptions.js
+++ b/javascript/net/grpc/web/clientoptions.js
@@ -25,6 +25,15 @@ class ClientOptions {
     this.withCredentials;
 
     /**
+     * The maximum allowed length, in bytes, of a single inbound message.
+     * Defaults to 4 MB (matching grpc-go, grpc-java and the C core). A value
+     * of 0 disables the limit. The stream parser rejects a frame whose
+     * declared length exceeds this before allocating a receive buffer.
+     * @type {number|undefined}
+     */
+    this.maxReceiveMessageSize;
+
+    /**
      * Unary interceptors. Note that they are only available in grpcweb and
      * grpcwebtext mode
      * @type {!Array<!UnaryInterceptor>|undefined}

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -79,6 +79,21 @@ class GrpcWebClientBase {
         goog.getObjectByName('withCredentials', options) || false;
 
     /**
+     * The maximum allowed inbound message length in bytes (0 = unlimited).
+     * @const
+     * @private {number}
+     */
+    let maxReceiveMessageSize = options.maxReceiveMessageSize;
+    if (maxReceiveMessageSize === undefined) {
+      maxReceiveMessageSize =
+          goog.getObjectByName('maxReceiveMessageSize', options);
+    }
+    this.maxReceiveMessageSize_ =
+        (maxReceiveMessageSize === undefined || maxReceiveMessageSize === null) ?
+        4 * 1024 * 1024 :
+        maxReceiveMessageSize;
+
+    /**
      * @const {!Array<!StreamInterceptor>}
      * @private
      */
@@ -220,7 +235,8 @@ class GrpcWebClientBase {
     const genericTransportInterface = {
       xhr: xhr,
     };
-    const stream = new GrpcWebClientReadableStream(genericTransportInterface);
+    const stream = new GrpcWebClientReadableStream(
+        genericTransportInterface, this.maxReceiveMessageSize_);
     stream.setResponseDeserializeFn(
         methodDescriptor.getResponseDeserializeFn());
 

--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -65,8 +65,10 @@ class GrpcWebClientReadableStream {
   /**
    * @param {!GenericTransportInterface} genericTransportInterface The
    *   GenericTransportInterface
+   * @param {number=} maxMessageLength The maximum allowed inbound message
+   *   length in bytes, forwarded to the stream parser. Defaults to 4 MB.
    */
-  constructor(genericTransportInterface) {
+  constructor(genericTransportInterface, maxMessageLength = 4 * 1024 * 1024) {
     /**
      * @const
      * @private
@@ -132,7 +134,7 @@ class GrpcWebClientReadableStream {
      * @type {!GrpcWebStreamParser} The grpc-web stream parser
      * @const
      */
-    this.parser_ = new GrpcWebStreamParser();
+    this.parser_ = new GrpcWebStreamParser(maxMessageLength);
 
     const self = this;
     events.listen(this.xhr_, EventType.READY_STATE_CHANGE, function(e) {

--- a/javascript/net/grpc/web/grpcwebstreamparser.js
+++ b/javascript/net/grpc/web/grpcwebstreamparser.js
@@ -53,7 +53,19 @@ const asserts = goog.require('goog.asserts');
  * @final
  */
 class GrpcWebStreamParser {
-  constructor() {
+  /**
+   * @param {number=} maxMessageLength The maximum allowed length, in bytes, of
+   *     a single inbound message. Defaults to 4 MB, matching the receive limit
+   *     enforced by grpc-go, grpc-java and the C core. A value of 0 disables
+   *     the check.
+   */
+  constructor(maxMessageLength = 4 * 1024 * 1024) {
+    /**
+     * The maximum allowed inbound message length in bytes (0 = unlimited).
+     * @private @const {number}
+     */
+    this.maxMessageLength_ = maxMessageLength;
+
     /**
      * The current error message, if any.
      * @private {?string}
@@ -212,9 +224,22 @@ class GrpcWebStreamParser {
      */
     function processLengthByte(b) {
       parser.countLengthBytes_++;
-      parser.length_ = (parser.length_ << 8) + b;
+      // Message-Length is a 4-byte unsigned big-endian integer (see
+      // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md).
+      // Multiply rather than left-shift: the JS `<<` operator coerces to a
+      // signed 32-bit int, which would misread any length >= 2^31 as negative.
+      parser.length_ = (parser.length_ * 256) + b;
 
       if (parser.countLengthBytes_ == 4) {  // no more length byte
+        // Reject an oversized (possibly attacker-controlled) length before
+        // allocating, so a bogus frame header cannot force a huge allocation.
+        if (parser.maxMessageLength_ > 0 &&
+            parser.length_ > parser.maxMessageLength_) {
+          throw new Error(
+              'grpc-web: message length ' + parser.length_ +
+              ' exceeds configured maximum of ' + parser.maxMessageLength_ +
+              ' bytes');
+        }
         parser.state_ = Parser.State_.MESSAGE;
         parser.countMessageBytes_ = 0;
         if (typeof Uint8Array !== 'undefined') {

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -107,6 +107,11 @@ declare module "grpc-web" {
     withCredentials?: boolean;
     unaryInterceptors?: UnaryInterceptor<unknown, unknown>[];
     streamInterceptors?: StreamInterceptor<unknown, unknown>[];
+    /**
+     * Maximum allowed inbound message size in bytes. Defaults to 4 MB.
+     * Set to 0 to disable the limit.
+     */
+    maxReceiveMessageSize?: number;
   }
 
   export class GrpcWebClientBase extends AbstractClientBase {


### PR DESCRIPTION
This PR brings parity in grpc web with other runtimes to limit the max received message size to 4MB

RELEASE NOTES: TBD