### PR TITLE
limit maxReceiveMessageSize to 4MB to have parity with other runtimes

### DIFF
--- a/javascript/net/grpc/web/clientoptions.js
+++ b/javascript/net/grpc/web/clientoptions.js
@@ -25,6 +25,15 @@ class ClientOptions {
     this.withCredentials;
 
     /**
+     * The maximum allowed length, in bytes, of a single inbound message.
+     * Defaults to 4 MB (matching grpc-go, grpc-java and the C core). A value
+     * of 0 disables the limit. The stream parser rejects a frame whose
+     * declared length exceeds this before allocating a receive buffer.
+     * @type {number|undefined}
+     */
+    this.maxReceiveMessageSize;
+
+    /**
      * Unary interceptors. Note that they are only available in grpcweb and
      * grpcwebtext mode
      * @type {!Array<!UnaryInterceptor>|undefined}

--- a/javascript/net/grpc/web/grpcwebclientbase.js
+++ b/javascript/net/grpc/web/grpcwebclientbase.js
@@ -79,6 +79,21 @@ class GrpcWebClientBase {
         goog.getObjectByName('withCredentials', options) || false;
 
     /**
+     * The maximum allowed inbound message length in bytes (0 = unlimited).
+     * @const
+     * @private {number}
+     */
+    let maxReceiveMessageSize = options.maxReceiveMessageSize;
+    if (maxReceiveMessageSize === undefined) {
+      maxReceiveMessageSize =
+          goog.getObjectByName('maxReceiveMessageSize', options);
+    }
+    this.maxReceiveMessageSize_ =
+        (maxReceiveMessageSize === undefined || maxReceiveMessageSize === null) ?
+        4 * 1024 * 1024 :
+        maxReceiveMessageSize;
+
+    /**
      * @const {!Array<!StreamInterceptor>}
      * @private
      */
@@ -220,7 +235,8 @@ class GrpcWebClientBase {
     const genericTransportInterface = {
       xhr: xhr,
     };
-    const stream = new GrpcWebClientReadableStream(genericTransportInterface);
+    const stream = new GrpcWebClientReadableStream(
+        genericTransportInterface, this.maxReceiveMessageSize_);
     stream.setResponseDeserializeFn(
         methodDescriptor.getResponseDeserializeFn());
 

--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -65,8 +65,10 @@ class GrpcWebClientReadableStream {
   /**
    * @param {!GenericTransportInterface} genericTransportInterface The
    *   GenericTransportInterface
+   * @param {number=} maxMessageLength The maximum allowed inbound message
+   *   length in bytes, forwarded to the stream parser. Defaults to 4 MB.
    */
-  constructor(genericTransportInterface) {
+  constructor(genericTransportInterface, maxMessageLength = 4 * 1024 * 1024) {
     /**
      * @const
      * @private
@@ -132,7 +134,7 @@ class GrpcWebClientReadableStream {
      * @type {!GrpcWebStreamParser} The grpc-web stream parser
      * @const
      */
-    this.parser_ = new GrpcWebStreamParser();
+    this.parser_ = new GrpcWebStreamParser(maxMessageLength);
 
     const self = this;
     events.listen(this.xhr_, EventType.READY_STATE_CHANGE, function(e) {

--- a/javascript/net/grpc/web/grpcwebclientreadablestream.js
+++ b/javascript/net/grpc/web/grpcwebclientreadablestream.js
@@ -163,8 +163,16 @@ class GrpcWebClientReadableStream {
       try {
         messages = self.parser_.parse(byteSource);
       } catch (err) {
-        self.handleError_(
-            new RpcError(StatusCode.UNKNOWN, 'Error in parsing response body'));
+        if (self.parser_.getMessageLengthExceeded()) {
+          // Mirror grpc-go/grpc-java/core, which return RESOURCE_EXHAUSTED when
+          // an inbound message exceeds the configured max receive message size.
+          self.handleError_(new RpcError(
+              StatusCode.RESOURCE_EXHAUSTED,
+              'Received message larger than max receive message size'));
+        } else {
+          self.handleError_(
+              new RpcError(StatusCode.UNKNOWN, 'Error in parsing response body'));
+        }
       }
       if (messages) {
         const FrameType = GrpcWebStreamParser.FrameType;

--- a/javascript/net/grpc/web/grpcwebstreamparser.js
+++ b/javascript/net/grpc/web/grpcwebstreamparser.js
@@ -53,7 +53,19 @@ const asserts = goog.require('goog.asserts');
  * @final
  */
 class GrpcWebStreamParser {
-  constructor() {
+  /**
+   * @param {number=} maxMessageLength The maximum allowed length, in bytes, of
+   *     a single inbound message. Defaults to 4 MB, matching the receive limit
+   *     enforced by grpc-go, grpc-java and the C core. A value of 0 disables
+   *     the check.
+   */
+  constructor(maxMessageLength = 4 * 1024 * 1024) {
+    /**
+     * The maximum allowed inbound message length in bytes (0 = unlimited).
+     * @private @const {number}
+     */
+    this.maxMessageLength_ = maxMessageLength;
+
     /**
      * The current error message, if any.
      * @private {?string}
@@ -212,9 +224,22 @@ class GrpcWebStreamParser {
      */
     function processLengthByte(b) {
       parser.countLengthBytes_++;
-      parser.length_ = (parser.length_ << 8) + b;
+      // Message-Length is a 4-byte unsigned big-endian integer (see
+      // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md).
+      // Multiply rather than left-shift: the JS `<<` operator coerces to a
+      // signed 32-bit int, which would misread any length >= 2^31 as negative.
+      parser.length_ = (parser.length_ * 256) + b;
 
       if (parser.countLengthBytes_ == 4) {  // no more length byte
+        // Reject an oversized (possibly attacker-controlled) length before
+        // allocating, so a bogus frame header cannot force a huge allocation.
+        if (parser.maxMessageLength_ > 0 &&
+            parser.length_ > parser.maxMessageLength_) {
+          throw new Error(
+              'grpc-web: message length ' + parser.length_ +
+              ' exceeds configured maximum of ' + parser.maxMessageLength_ +
+              ' bytes');
+        }
         parser.state_ = Parser.State_.MESSAGE;
         parser.countMessageBytes_ = 0;
         if (typeof Uint8Array !== 'undefined') {

--- a/javascript/net/grpc/web/grpcwebstreamparser.js
+++ b/javascript/net/grpc/web/grpcwebstreamparser.js
@@ -67,6 +67,14 @@ class GrpcWebStreamParser {
     this.maxMessageLength_ = maxMessageLength;
 
     /**
+     * Whether parsing failed because a frame declared a length exceeding
+     * maxMessageLength_. Lets the caller surface StatusCode.RESOURCE_EXHAUSTED
+     * (matching grpc-go/grpc-java/core) instead of a generic parse error.
+     * @private {boolean}
+     */
+    this.messageLengthExceeded_ = false;
+
+    /**
      * The current error message, if any.
      * @private {?string}
      */
@@ -134,6 +142,15 @@ class GrpcWebStreamParser {
    */
   getErrorMessage() {
     return this.errorMessage_;
+  }
+
+  /**
+   * Whether the last parse failure was caused by a message whose declared
+   * length exceeded the configured maxMessageLength_.
+   * @return {boolean}
+   */
+  getMessageLengthExceeded() {
+    return this.messageLengthExceeded_;
   }
 
   /**
@@ -233,12 +250,17 @@ class GrpcWebStreamParser {
       if (parser.countLengthBytes_ == 4) {  // no more length byte
         // Reject an oversized (possibly attacker-controlled) length before
         // allocating, so a bogus frame header cannot force a huge allocation.
+        // error_() marks the stream INVALID and throws, consistent with the
+        // other framing errors in this parser; the flag lets the caller map
+        // this to RESOURCE_EXHAUSTED.
         if (parser.maxMessageLength_ > 0 &&
             parser.length_ > parser.maxMessageLength_) {
-          throw new Error(
-              'grpc-web: message length ' + parser.length_ +
-              ' exceeds configured maximum of ' + parser.maxMessageLength_ +
-              ' bytes');
+          parser.messageLengthExceeded_ = true;
+          parser.error_(
+              inputBytes, pos,
+              'message length ' + parser.length_ +
+                  ' exceeds max receive message size ' +
+                  parser.maxMessageLength_);
         }
         parser.state_ = Parser.State_.MESSAGE;
         parser.countMessageBytes_ = 0;

--- a/javascript/net/grpc/web/grpcwebstreamparser_test.js
+++ b/javascript/net/grpc/web/grpcwebstreamparser_test.js
@@ -226,4 +226,59 @@ testSuite({
     assertElementsEquals([38, 39], message[FrameType.DATA]);
   },
 
+  // A message whose declared length is within the configured limit parses
+  // normally and does not flag the stream as exceeded.
+  testMessageLengthWithinLimit: function() {
+    var boundedParser = new GrpcWebStreamParser(2);
+    var arr = new Uint8Array([0, 0, 0, 0, 2, 38, 39]);  // DATA, length 2
+    var messages = boundedParser.parse(arr.buffer);
+    assertEquals(1, messages.length);
+    assertElementsEquals([38, 39], messages[0][FrameType.DATA]);
+    assertFalse(boundedParser.getMessageLengthExceeded());
+    assertTrue(boundedParser.isInputValid());
+  },
+
+  // A frame declaring a length greater than the configured maximum is rejected
+  // on the length prefix alone -- the body is withheld here, mirroring the DoS
+  // vector -- before any receive buffer is allocated. The stream is marked
+  // invalid and flagged so the caller can surface RESOURCE_EXHAUSTED.
+  testMessageLengthExceedsLimit: function() {
+    var boundedParser = new GrpcWebStreamParser(2);
+    var header = new Uint8Array([0, 0, 0, 0, 3]);  // DATA, length 3, no body
+    var err = assertThrows(function() {
+      boundedParser.parse(header.buffer);
+    });
+    assertTrue(boundedParser.getMessageLengthExceeded());
+    assertFalse(boundedParser.isInputValid());
+    assertTrue(
+        err.message.indexOf('exceeds max receive message size') != -1);
+  },
+
+  // The exact reported vector: a DATA frame advertising 0x7fffffff (~2 GB) with
+  // the body withheld must be rejected by the default 4 MB parser.
+  testDefaultLimitRejectsOversizedLength: function() {
+    var header = new Uint8Array([0, 127, 255, 255, 255]);  // length 0x7fffffff
+    assertThrows(function() { parser.parse(header.buffer); });
+    assertTrue(parser.getMessageLengthExceeded());
+  },
+
+  // 0x80000000 has the high bit set. A signed `<< 8` decode would read this as
+  // negative and slip past the `> max` check (then attempt a negative-size
+  // allocation); the unsigned decode treats it as ~2 GB and rejects it.
+  testLengthPrefixDecodedAsUnsigned: function() {
+    var boundedParser = new GrpcWebStreamParser(1024);
+    var header = new Uint8Array([0, 128, 0, 0, 0]);  // length 0x80000000
+    assertThrows(function() { boundedParser.parse(header.buffer); });
+    assertTrue(boundedParser.getMessageLengthExceeded());
+  },
+
+  // A maximum of 0 disables the check; normal messages still parse.
+  testZeroMaxDisablesLimit: function() {
+    var unlimitedParser = new GrpcWebStreamParser(0);
+    var arr = new Uint8Array([0, 0, 0, 0, 2, 38, 39]);
+    var messages = unlimitedParser.parse(arr.buffer);
+    assertEquals(1, messages.length);
+    assertFalse(unlimitedParser.getMessageLengthExceeded());
+  },
+
 });

--- a/packages/grpc-web/index.d.ts
+++ b/packages/grpc-web/index.d.ts
@@ -111,6 +111,11 @@ declare module "grpc-web" {
     withCredentials?: boolean;
     unaryInterceptors?: UnaryInterceptor<unknown, unknown>[];
     streamInterceptors?: StreamInterceptor<unknown, unknown>[];
+    /**
+     * Maximum allowed inbound message size in bytes. Defaults to 4 MB.
+     * Set to 0 to disable the limit.
+     */
+    maxReceiveMessageSize?: number;
   }
 
   export class GrpcWebClientBase extends AbstractClientBase {


### PR DESCRIPTION
Release Notes: TBD