### PR TITLE
fix: update the docker toolchain to supported versions

### DIFF
--- a/net/grpc/gateway/docker/binary_client/Dockerfile
+++ b/net/grpc/gateway/docker/binary_client/Dockerfile
@@ -31,4 +31,4 @@ RUN npm install && \
 WORKDIR /var/www/html
 
 EXPOSE 8081
-CMD ["python", "-m", "SimpleHTTPServer", "8081"]
+CMD ["python3", "-m", "http.server", "8081"]

--- a/net/grpc/gateway/docker/closure_client/Dockerfile
+++ b/net/grpc/gateway/docker/closure_client/Dockerfile
@@ -23,4 +23,4 @@ RUN make client && make install
 WORKDIR /var/www/html
 
 EXPOSE 8081
-CMD ["python", "-m", "SimpleHTTPServer", "8081"]
+CMD ["python3", "-m", "http.server", "8081"]

--- a/net/grpc/gateway/docker/commonjs_client/Dockerfile
+++ b/net/grpc/gateway/docker/commonjs_client/Dockerfile
@@ -31,4 +31,4 @@ RUN npm install && \
 WORKDIR /var/www/html
 
 EXPOSE 8081
-CMD ["python", "-m", "SimpleHTTPServer", "8081"]
+CMD ["python3", "-m", "http.server", "8081"]

--- a/net/grpc/gateway/docker/interop_client/Dockerfile
+++ b/net/grpc/gateway/docker/interop_client/Dockerfile
@@ -32,4 +32,4 @@ RUN npm install && \
 WORKDIR /var/www/html
 
 EXPOSE 8081
-CMD ["python", "-m", "SimpleHTTPServer", "8081"]
+CMD ["python3", "-m", "http.server", "8081"]

--- a/net/grpc/gateway/docker/prereqs/Dockerfile
+++ b/net/grpc/gateway/docker/prereqs/Dockerfile
@@ -18,11 +18,12 @@
 ######################################
 # Stage 1: Fetch binaries
 ######################################
-# node:... Docker image is based on buildpack-deps:bullseye (11)
-FROM buildpack-deps:bullseye AS prepare
+# node:... Docker image is based on buildpack-deps:trixie (13)
+FROM buildpack-deps:trixie AS prepare
 
-ARG BUILDIFIER_VERSION=1.0.0
-ARG PROTOBUF_VERSION=3.19.4
+ARG BUILDIFIER_VERSION=8.5.1
+ARG PROTOBUF_VERSION=36.1
+ARG PROTOBUF_JS_VERSION=3.21.4
 
 RUN apt-get -qq update && apt-get -qq install -y curl unzip
 
@@ -33,8 +34,14 @@ protoc-$PROTOBUF_VERSION-linux-x86_64.zip -o protoc.zip && \
   unzip -qq protoc.zip && \
   cp ./bin/protoc /usr/local/bin/protoc
 
+RUN curl -sSL https://github.com/protocolbuffers/protobuf-javascript/releases/download/\
+v$PROTOBUF_JS_VERSION/protobuf-javascript-$PROTOBUF_JS_VERSION-linux-x86_64.tar.gz -o protobuf-js.tar.gz && \
+  mkdir -p ./protobuf-js && \
+  tar -xzf protobuf-js.tar.gz -C ./protobuf-js && \
+  cp ./protobuf-js/bin/protoc-gen-js /usr/local/bin/protoc-gen-js
+
 RUN wget -nv -O buildifier \
-  https://github.com/bazelbuild/buildtools/releases/download/$BUILDIFIER_VERSION/buildifier && \
+  https://github.com/bazelbuild/buildtools/releases/download/v$BUILDIFIER_VERSION/buildifier-linux-amd64 && \
   chmod +x ./buildifier && \
   cp ./buildifier /usr/local/bin/buildifier
 
@@ -48,17 +55,18 @@ RUN ./scripts/init_submodules.sh
 ######################################
 # Stage 2: Copy source files and build
 ######################################
-FROM node:20.0.0-bullseye AS copy-and-build
+FROM node:24-trixie AS copy-and-build
 
 ARG MAKEFLAGS=-j8
 ARG BAZEL_VERSION=7.3.0
 
-RUN apt-get -qq update && apt-get -qq install -y python
+RUN apt-get -qq update && apt-get -qq install -y python3 python-is-python3
 
 RUN mkdir -p /var/www/html/dist
 RUN echo "\nloglevel=error\n" >> $HOME/.npmrc
 
 COPY --from=prepare /usr/local/bin/protoc /usr/local/bin/
+COPY --from=prepare /usr/local/bin/protoc-gen-js /usr/local/bin/
 COPY --from=prepare /usr/local/bin/buildifier /usr/local/bin/
 COPY --from=prepare /github/grpc-web/third_party /github/grpc-web/third_party
 

--- a/net/grpc/gateway/docker/ts_client/Dockerfile
+++ b/net/grpc/gateway/docker/ts_client/Dockerfile
@@ -40,4 +40,4 @@ RUN npm install && \
 WORKDIR /var/www/html
 
 EXPOSE 8081
-CMD ["python", "-m", "SimpleHTTPServer", "8081"]
+CMD ["python3", "-m", "http.server", "8081"]


### PR DESCRIPTION
Fixes #1554.

Both stages of `prereqs/Dockerfile` target Debian 11, whose release file is expired, so `apt-get update` fails with exit code 100.

Changes:

- `buildpack-deps:bullseye` -> `buildpack-deps:trixie`, `node:20.0.0-bullseye` -> `node:24-trixie`
- buildifier 1.0.0 -> 8.5.1, whose asset is now `buildifier-linux-amd64`
- protoc 3.19.4 -> 36.1, plus `protoc-gen-js` 3.21.4 for the `--js_out` that protoc dropped in v21
- `python` -> `python3` `python-is-python3`, and the clients serve with `python3 -m http.server` instead of `python -m SimpleHTTPServer`
